### PR TITLE
feat(website): static multilingual HTML generation for SEO

### DIFF
--- a/docs/plans/2026-03-31-website-seo-multilingual-design.md
+++ b/docs/plans/2026-03-31-website-seo-multilingual-design.md
@@ -1,0 +1,153 @@
+# 網站 SEO 多語言靜態化設計
+
+> 日期：2026-03-31
+> 狀態：已驗證
+
+## 問題
+
+現有網站使用 client-side i18n.js 動態替換文字和 meta tags，搜尋引擎爬蟲只看到初始 HTML（中文），英文內容無法被索引。另有 JSON-LD 錯誤、缺少 og:image、缺少 hreflang 等 SEO 問題。
+
+## 設計決策
+
+- 方案：建置腳本生成靜態多語言 HTML（方案 B + 選項 2）
+- 預設語言：英文
+- 網域：`n8n-skills.frankchen.tw`
+- URL 結構：`/`（EN）、`/zh-TW/`（ZH-TW）
+
+## 檔案結構
+
+```
+website/
+├── template.html          # 新增：HTML 模板（含 {{placeholder}}）
+├── index.html             # 生成：英文版（預設）
+├── zh-TW/
+│   └── index.html         # 生成：中文版
+├── styles.css             # 不動
+├── script.js              # 不動
+├── i18n.js                # 改造：僅做語言切換導向
+├── locales/               # 不動（作為模板資料來源）
+├── robots.txt             # 更新 URL
+├── sitemap.xml            # 更新：兩個 URL
+└── assets/                # 不動
+```
+
+## 模板機制
+
+### 佔位符
+
+用 `{{key.path}}` 對應 locales JSON 結構。特殊變數：
+
+| 變數 | 英文版 | 中文版 |
+|------|--------|--------|
+| `{{__lang__}}` | `en` | `zh-TW` |
+| `{{__canonical__}}` | `https://n8n-skills.frankchen.tw/` | `https://n8n-skills.frankchen.tw/zh-TW/` |
+| `{{__base_path__}}` | `./` | `../` |
+| `{{__alt_lang_url__}}` | `https://n8n-skills.frankchen.tw/zh-TW/` | `https://n8n-skills.frankchen.tw/` |
+| `{{__alt_lang_label__}}` | `中文` | `English` |
+
+### 生成流程
+
+對每個語言：
+1. 讀取 template.html
+2. 讀取 locales/{lang}.json
+3. 計算特殊變數
+4. 遞迴替換所有 `{{key.path}}` 佔位符
+5. 注入社群套件卡片（維持 marker 機制）
+6. 注入統計數字
+7. 寫入目標路徑
+
+### data-i18n 屬性
+
+模板中移除所有 `data-i18n` 和 `data-i18n-aria` 屬性。文字由佔位符替換直接寫死，生成後的 HTML 是純靜態。
+
+## SEO 修正
+
+### hreflang（每頁都有）
+
+```html
+<link rel="alternate" hreflang="en" href="https://n8n-skills.frankchen.tw/">
+<link rel="alternate" hreflang="zh-TW" href="https://n8n-skills.frankchen.tw/zh-TW/">
+<link rel="alternate" hreflang="x-default" href="https://n8n-skills.frankchen.tw/">
+```
+
+### JSON-LD
+
+- 移除 `aggregateRating`（僅 1 個評分，Google 視為可疑）
+- 移除 `screenshot`（指向首頁非圖片）
+- `description` 各語言版本直接寫在生成的 HTML 中
+
+### 新增 meta 標籤
+
+- `og:image` / `twitter:image`：使用 `assets/n8n-skills-icon.png`
+- `<link rel="icon">`：使用 `assets/n8n-skills-icon.png`
+
+### H1 改善
+
+- 英文：`n8n Skills — Turn your AI assistant into an n8n workflow expert`
+- 中文：`n8n Skills — 讓 AI 助理成為你的 n8n 工作流程專家`
+- 用 hero.subtitle 佔位符：`<h1>n8n Skills — {{hero.subtitle}}</h1>`
+
+### sitemap.xml
+
+```xml
+<url>
+  <loc>https://n8n-skills.frankchen.tw/</loc>
+  <lastmod>YYYY-MM-DD</lastmod>
+  <changefreq>weekly</changefreq>
+  <priority>1.0</priority>
+</url>
+<url>
+  <loc>https://n8n-skills.frankchen.tw/zh-TW/</loc>
+  <lastmod>YYYY-MM-DD</lastmod>
+  <changefreq>weekly</changefreq>
+  <priority>0.9</priority>
+</url>
+```
+
+## i18n.js 改造
+
+從 ~190 行縮減到 ~20 行，只做：
+1. 語言切換按鈕綁定 — 點擊跳轉到另一語言頁面
+2. 當前語言判斷 — 從 `window.location.pathname` 判斷
+
+移除：`loadTranslations()`、`updatePageContent()`、`updateMetaTags()`、localStorage。
+
+## update-website.ts 改動
+
+### 新增方法
+
+- `generateLocalizedPages()` — 讀模板 + locale JSON → 生成兩份 HTML
+
+### 移除方法
+
+- `updateIndexHtml()` — 被 `generateLocalizedPages()` 取代
+
+### 保留方法
+
+- `collectData()` — 不動
+- `updateReadmeEn()` / `updateReadmeZhTW()` — 不動
+- `updateLocaleEn()` / `updateLocaleZhTW()` — 保留，locale JSON 仍是模板資料來源
+- `updateCommunityPackages()` — 拆成：生成卡片 HTML 字串 + 在生成頁面時注入
+- `updateSitemap()` — 改為生成包含兩個 URL 的 sitemap
+
+### 執行順序
+
+```
+1. collectData()
+2. updateReadmeEn() + updateReadmeZhTW()
+3. updateLocaleEn() + updateLocaleZhTW()     ← 先更新 locale JSON 數字
+4. generateLocalizedPages()                    ← 再用更新後的 locale 生成 HTML
+5. updateSitemap()
+```
+
+## CSS/JS 路徑
+
+模板中用 `{{__base_path__}}` 前綴：
+```html
+<link rel="stylesheet" href="{{__base_path__}}styles.css">
+<script src="{{__base_path__}}i18n.js"></script>
+<script src="{{__base_path__}}script.js"></script>
+<link rel="icon" href="{{__base_path__}}assets/n8n-skills-icon.png">
+```
+
+英文版 `./`，中文版 `../`。

--- a/docs/plans/2026-03-31-website-seo-multilingual-plan.md
+++ b/docs/plans/2026-03-31-website-seo-multilingual-plan.md
@@ -1,0 +1,586 @@
+# Website SEO Multilingual Static Generation — Implementation Plan
+
+Goal: Convert client-side i18n to build-time static HTML generation with proper SEO (hreflang, JSON-LD, og:image)
+
+Architecture: Create `template.html` with `{{key.path}}` placeholders. `update-website.ts` reads template + locale JSONs → generates `index.html` (EN) and `zh-TW/index.html` (ZH-TW). i18n.js reduced to URL-based language redirector. Domain changed to `n8n-skills.frankchen.tw`.
+
+Tech Stack: TypeScript (build script), vanilla HTML/CSS/JS (website)
+
+---
+
+### Task 1: Update locale JSONs — add aria keys
+
+Files:
+- Modify: `website/locales/en.json`
+- Modify: `website/locales/zh-TW.json`
+
+Step 1: Add `aria` section to `website/locales/en.json`
+
+Add after the `"nav"` section:
+
+```json
+"aria": {
+  "githubProject": "Visit n8n Skills GitHub repository",
+  "downloadLatest": "Download the latest version of n8n Skills"
+},
+```
+
+Step 2: Add `aria` section to `website/locales/zh-TW.json`
+
+Add after the `"nav"` section:
+
+```json
+"aria": {
+  "githubProject": "前往 n8n Skills GitHub 專案",
+  "downloadLatest": "下載最新版本的 n8n Skills"
+},
+```
+
+Step 3: Commit
+
+```bash
+git add website/locales/en.json website/locales/zh-TW.json
+git commit -m "feat(website): add aria keys to locale JSONs for template system"
+```
+
+---
+
+### Task 2: Create template.html from index.html
+
+Files:
+- Create: `website/template.html`
+
+This is the core task. Transform `website/index.html` into a template with `{{key.path}}` placeholders.
+
+Step 1: Copy `website/index.html` to `website/template.html`
+
+Step 2: Apply the following transformations to `website/template.html`:
+
+**A. HTML lang and resource paths:**
+- `<html lang="zh-TW">` → `<html lang="{{__lang__}}">`
+- `href="styles.css"` → `href="{{__base_path__}}styles.css"`
+- `src="i18n.js"` → `src="{{__base_path__}}i18n.js"`
+- `src="script.js"` → `src="{{__base_path__}}script.js"`
+- `src="assets/n8n-skills-icon.png"` → `src="{{__base_path__}}assets/n8n-skills-icon.png"`
+
+**B. Meta tags — replace entire `<head>` meta block (lines 8-33) with:**
+```html
+    <!-- Primary Meta Tags -->
+    <title>{{meta.title}}</title>
+    <meta name="title" content="{{meta.title}}">
+    <meta name="description" content="{{meta.description}}">
+    <meta name="keywords" content="{{meta.keywords}}">
+    <meta name="author" content="Frank Chen">
+    <meta name="robots" content="index, follow">
+    <link rel="canonical" href="{{__canonical__}}">
+    <link rel="icon" href="{{__base_path__}}assets/n8n-skills-icon.png">
+
+    <!-- Hreflang -->
+    <link rel="alternate" hreflang="en" href="https://n8n-skills.frankchen.tw/">
+    <link rel="alternate" hreflang="zh-TW" href="https://n8n-skills.frankchen.tw/zh-TW/">
+    <link rel="alternate" hreflang="x-default" href="https://n8n-skills.frankchen.tw/">
+
+    <!-- Open Graph / Facebook -->
+    <meta property="og:type" content="website">
+    <meta property="og:url" content="{{__canonical__}}">
+    <meta property="og:title" content="{{meta.title}}">
+    <meta property="og:description" content="{{meta.description}}">
+    <meta property="og:locale" content="{{__og_locale__}}">
+    <meta property="og:image" content="https://n8n-skills.frankchen.tw/assets/n8n-skills-icon.png">
+
+    <!-- Twitter -->
+    <meta property="twitter:card" content="summary_large_image">
+    <meta property="twitter:url" content="{{__canonical__}}">
+    <meta property="twitter:title" content="{{meta.title}}">
+    <meta property="twitter:description" content="{{meta.description}}">
+    <meta property="twitter:image" content="https://n8n-skills.frankchen.tw/assets/n8n-skills-icon.png">
+```
+
+Note: `{{__og_locale__}}` is a new special variable — `en_US` for EN, `zh_TW` for ZH-TW.
+
+**C. JSON-LD — replace entire script block (lines 44-69) with:**
+```html
+    <script type="application/ld+json">
+    {
+      "@context": "https://schema.org",
+      "@type": "SoftwareApplication",
+      "name": "n8n Skills",
+      "applicationCategory": "DeveloperApplication",
+      "offers": {
+        "@type": "Offer",
+        "price": "0",
+        "priceCurrency": "USD"
+      },
+      "operatingSystem": "Cross-platform",
+      "description": "{{meta.description}}",
+      "author": {
+        "@type": "Person",
+        "name": "Frank Chen"
+      },
+      "url": "https://n8n-skills.frankchen.tw/"
+    }
+    </script>
+```
+
+(Removed `aggregateRating` and `screenshot`)
+
+**D. Language toggle button — replace (lines 74-77) with:**
+```html
+    <button id="lang-toggle" class="lang-toggle-fixed" onclick="window.location.href='{{__alt_lang_url__}}'">
+        <span class="lang-icon">🌐</span>
+        <span class="lang-text">{{__alt_lang_label__}}</span>
+    </button>
+```
+
+**E. Navbar — replace data-i18n attributes with placeholders:**
+- `data-i18n-aria="aria.githubProject"` → `aria-label="{{aria.githubProject}}"`
+- `data-i18n="nav.getStarted" data-i18n-aria="aria.downloadLatest"` on the "開始使用" link → remove both data-i18n attrs, set text to `{{nav.getStarted}}` and add `aria-label="{{aria.downloadLatest}}"`
+
+**F. Hero section:**
+- Replace `<h1 class="hero-title">n8n Skills</h1>` with `<h1 class="hero-title">n8n Skills<span class="hero-title-separator"> — </span><span class="hero-title-sub">{{hero.subtitle}}</span></h1>`
+- Replace `<p class="hero-subtitle" data-i18n="hero.subtitle">讓 AI 助理成為你的 n8n 工作流程專家</p>` — remove this element entirely (subtitle is now in H1)
+- Replace `<p class="hero-description" data-i18n="hero.description">545 個節點的完整知識庫，定期更新，智慧排序</p>` → `<p class="hero-description">{{hero.description}}</p>`
+- Hero buttons: same pattern as navbar — remove `data-i18n`/`data-i18n-aria`, use `{{key}}` for text and `aria-label="{{key}}"` for aria
+
+**G. Stats section — replace all `data-i18n` with placeholders:**
+- `<div class="stat-label" data-i18n="stats.nodes">n8n 節點</div>` → `<div class="stat-label">{{stats.nodes}}</div>`
+- Same for stats.categories, stats.templates, stats.communityPackages, stats.clickToExpand
+
+**H. Community section:**
+- `<h3 ... data-i18n="community.title">社群套件推薦</h3>` → `<h3 ...>{{community.title}}</h3>`
+- Keep the `<!-- BEGIN COMMUNITY_PACKAGES_LIST -->...<!-- END COMMUNITY_PACKAGES_LIST -->` markers intact
+
+**I. Features section — all data-i18n → placeholders:**
+- `data-i18n="features.title"` → text `{{features.title}}`
+- `data-i18n="features.comprehensive.title"` → text `{{features.comprehensive.title}}`
+- `data-i18n="features.comprehensive.description"` → text `{{features.comprehensive.description}}`
+- Same pattern for all other feature cards (integration, priority, updates, structure)
+
+**J. How It Works section — all data-i18n → placeholders:**
+- `data-i18n="howItWorks.title"` → text `{{howItWorks.title}}`
+- `data-i18n="howItWorks.step1.title"` → text `{{howItWorks.step1.title}}`
+- Same for step1.description, step2.title, step2.description, step3.title, step3.description
+
+**K. Installation section — all data-i18n → placeholders:**
+- `data-i18n="installation.title"` → text `{{installation.title}}`
+- `data-i18n="installation.subtitle"` → text `{{installation.subtitle}}`
+- `data-i18n="installation.plugin.title"` → text `{{installation.plugin.title}}`
+- `data-i18n="installation.plugin.description"` → text `{{installation.plugin.description}}`
+- `data-i18n="installation.plugin.badge"` → text `{{installation.plugin.badge}}`
+- `data-i18n="installation.manual.title"` → text `{{installation.manual.title}}`
+- `data-i18n="installation.manual.description"` → text `{{installation.manual.description}}`
+- `<span data-i18n="installation.manual.button">下載 ZIP</span>` → `<span>{{installation.manual.button}}</span>`
+
+**L. Categories section — all data-i18n → placeholders:**
+- `data-i18n="categories.title"` → text `{{categories.title}}`
+- All category cards: same pattern (core, apps, triggers, ai, database, tools)
+
+**M. Footer — all data-i18n → placeholders + fix asset path:**
+- `src="assets/n8n-skills-icon.png"` → `src="{{__base_path__}}assets/n8n-skills-icon.png"`
+- `data-i18n="footer.brandName"` → text `{{footer.brandName}}`
+- `data-i18n="footer.slogan"` → text `{{footer.slogan}}`
+- `data-i18n="footer.productInfo"` → text `{{footer.productInfo}}`
+- `data-i18n="footer.features"` → text `{{footer.features}}`
+- `data-i18n="footer.howToUse"` → text `{{footer.howToUse}}`
+- `data-i18n="footer.otherResources"` → text `{{footer.otherResources}}`
+- `data-i18n="footer.home"` → text `{{footer.home}}`
+- `data-i18n="footer.n8nTutorial"` → text `{{footer.n8nTutorial}}`
+- `data-i18n="footer.aboutMe"` → text `{{footer.aboutMe}}`
+- `data-i18n="footer.contactMe"` → text `{{footer.contactMe}}`
+- `data-i18n="footer.copyright"` → text `{{footer.copyright}}`
+
+**N. Verify: No `data-i18n` attributes remain in template.html:**
+```bash
+grep -c 'data-i18n' website/template.html
+# Expected: 0
+```
+
+Step 3: Commit
+
+```bash
+git add website/template.html
+git commit -m "feat(website): create template.html with i18n placeholders and SEO fixes"
+```
+
+---
+
+### Task 3: Rewrite i18n.js as URL-based language redirector
+
+Files:
+- Modify: `website/i18n.js`
+
+Step 1: Replace entire `website/i18n.js` with:
+
+```javascript
+// Language switcher — detects current language from URL path
+(function() {
+  function getCurrentLang() {
+    return window.location.pathname.includes('/zh-TW') ? 'zh-TW' : 'en';
+  }
+
+  function getAltUrl() {
+    const loc = window.location;
+    if (getCurrentLang() === 'zh-TW') {
+      // Remove /zh-TW/ from path
+      return loc.origin + loc.pathname.replace(/\/zh-TW\/?/, '/') + loc.search + loc.hash;
+    } else {
+      // Add /zh-TW/ before trailing path
+      const base = loc.pathname.replace(/\/$/, '');
+      return loc.origin + base + '/zh-TW/' + loc.search + loc.hash;
+    }
+  }
+
+  window.i18nLang = getCurrentLang();
+  window.i18nGetAltUrl = getAltUrl;
+})();
+```
+
+Step 2: Commit
+
+```bash
+git add website/i18n.js
+git commit -m "refactor(website): simplify i18n.js to URL-based language detection"
+```
+
+---
+
+### Task 4: Update script.js — remove i18n initialization
+
+Files:
+- Modify: `website/script.js`
+
+Step 1: Replace the DOMContentLoaded handler and related functions.
+
+Remove all i18n initialization code (lines 7-31: `window.i18n = new I18n()`, `await window.i18n.init()`, language toggle setup, `updateLangToggleButton`).
+
+Remove the `updateCategoryLabels` function and its event listener (lines 94-132).
+
+The resulting `script.js` should only contain:
+1. DOMContentLoaded handler with navbar IntersectionObserver logic
+2. `initCommunityPackages()` — but remove the `updateCategoryLabels` call and event listener (lines 95-99)
+3. Copy button functionality (unchanged)
+
+Step 2: Commit
+
+```bash
+git add website/script.js
+git commit -m "refactor(website): remove client-side i18n from script.js"
+```
+
+---
+
+### Task 5: Update update-website.ts — add generateLocalizedPages()
+
+Files:
+- Modify: `scripts/update-website.ts`
+
+Step 1: Add `SITE_DOMAIN` constant and `LocaleConfig` interface at the top of the class:
+
+```typescript
+private readonly SITE_DOMAIN = 'https://n8n-skills.frankchen.tw';
+
+private readonly localeConfigs: Array<{
+  lang: string;
+  outputPath: string;
+  basePath: string;
+  ogLocale: string;
+  altLangLabel: string;
+}> = [
+  {
+    lang: 'en',
+    outputPath: 'index.html',
+    basePath: './',
+    ogLocale: 'en_US',
+    altLangLabel: '中文',
+  },
+  {
+    lang: 'zh-TW',
+    outputPath: 'zh-TW/index.html',
+    basePath: '../',
+    ogLocale: 'zh_TW',
+    altLangLabel: 'English',
+  },
+];
+```
+
+Step 2: Add `generateLocalizedPages()` method:
+
+```typescript
+private async generateLocalizedPages(): Promise<void> {
+  const templatePath = path.join(this.websiteDir, 'template.html');
+  const template = await fs.readFile(templatePath, 'utf-8');
+
+  for (const config of this.localeConfigs) {
+    const localePath = path.join(this.websiteDir, 'locales', `${config.lang}.json`);
+    const localeContent = await fs.readFile(localePath, 'utf-8');
+    const locale = JSON.parse(localeContent);
+
+    // Build special variables
+    const canonical = config.lang === 'en'
+      ? `${this.SITE_DOMAIN}/`
+      : `${this.SITE_DOMAIN}/zh-TW/`;
+    const altLangUrl = config.lang === 'en'
+      ? `${this.SITE_DOMAIN}/zh-TW/`
+      : `${this.SITE_DOMAIN}/`;
+
+    const specialVars: Record<string, string> = {
+      '__lang__': config.lang,
+      '__canonical__': canonical,
+      '__base_path__': config.basePath,
+      '__og_locale__': config.ogLocale,
+      '__alt_lang_url__': altLangUrl,
+      '__alt_lang_label__': config.altLangLabel,
+    };
+
+    // Replace placeholders
+    let html = template;
+
+    // Replace special variables first
+    for (const [key, value] of Object.entries(specialVars)) {
+      html = html.replace(new RegExp(`\\{\\{${key}\\}\\}`, 'g'), value);
+    }
+
+    // Replace locale variables (supports nested keys like {{meta.title}})
+    html = html.replace(/\{\{([a-zA-Z][a-zA-Z0-9_.]*)\}\}/g, (_match, keyPath: string) => {
+      const keys = keyPath.split('.');
+      let value: unknown = locale;
+      for (const k of keys) {
+        if (value && typeof value === 'object') {
+          value = (value as Record<string, unknown>)[k];
+        } else {
+          return `{{${keyPath}}}`; // Keep unresolved
+        }
+      }
+      return typeof value === 'string' ? value : `{{${keyPath}}}`;
+    });
+
+    // Ensure output directory exists
+    const outputPath = path.join(this.websiteDir, config.outputPath);
+    await fs.mkdir(path.dirname(outputPath), { recursive: true });
+    await fs.writeFile(outputPath, html, 'utf-8');
+    info(`Generated ${config.outputPath} (${config.lang})`);
+  }
+}
+```
+
+Step 3: Update `updateSitemap()` to generate both URLs with new domain:
+
+```typescript
+private async updateSitemap(timestamp: string): Promise<void> {
+  const sitemapPath = path.join(this.websiteDir, 'sitemap.xml');
+  const lastmod = timestamp.split('T')[0];
+
+  const content = `<?xml version="1.0" encoding="UTF-8"?>
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+    <url>
+        <loc>${this.SITE_DOMAIN}/</loc>
+        <lastmod>${lastmod}</lastmod>
+        <changefreq>weekly</changefreq>
+        <priority>1.0</priority>
+    </url>
+    <url>
+        <loc>${this.SITE_DOMAIN}/zh-TW/</loc>
+        <lastmod>${lastmod}</lastmod>
+        <changefreq>weekly</changefreq>
+        <priority>0.9</priority>
+    </url>
+</urlset>
+`;
+
+  await fs.writeFile(sitemapPath, content, 'utf-8');
+  info('sitemap.xml update completed');
+}
+```
+
+Step 4: Update `updateCommunityPackages()` — change it to inject into template instead of index.html.
+
+The community packages are injected via `<!-- BEGIN/END COMMUNITY_PACKAGES_LIST -->` markers which are already in the template. The `updateCommunityPackages()` method currently reads/writes `index.html`. Change it to read/write `template.html` instead, and remove the stats card count update (that will be a separate stat number injection in the template).
+
+Change `const indexPath = path.join(this.websiteDir, 'index.html');` to `const templatePath = path.join(this.websiteDir, 'template.html');` in `updateCommunityPackages()`.
+
+Remove the stats card count update block at the end of `updateCommunityPackages()` (lines 586-589 that update `stat-number` for communityPackages).
+
+Step 5: Update `updateIndexHtml()` — rename to `updateTemplateStats()` and change to update `template.html` instead.
+
+This method needs to update the hardcoded stat numbers in the template (the `<div class="stat-number">545</div>` etc). It should:
+- Read/write `template.html` instead of `index.html`
+- Only update the stat-number divs (node count, template count, community package count)
+- Remove all the meta/feature/footer text updates (those are now handled by locale JSONs + placeholders)
+
+```typescript
+private async updateTemplateStats(data: UpdateData): Promise<void> {
+  const templatePath = path.join(this.websiteDir, 'template.html');
+  let content = await fs.readFile(templatePath, 'utf-8');
+
+  // Update node count stat card
+  content = content.replace(
+    /(<div class="stat-number">)\d+(<\/div>\s*<div class="stat-label">{{stats\.nodes}})/s,
+    `$1${data.actualNodeCount}$2`
+  );
+
+  // Update template count stat card
+  content = content.replace(
+    /(<div class="stat-number">)\d+(<\/div>\s*<div class="stat-label">{{stats\.templates}})/s,
+    `$1${data.templateCount}$2`
+  );
+
+  // Update community packages count stat card
+  content = content.replace(
+    /(<div class="stat-number">)\d+(<\/div>\s*<div class="stat-label">{{stats\.communityPackages}})/s,
+    `$1${data.communityPackageCount}$2`
+  );
+
+  await fs.writeFile(templatePath, content, 'utf-8');
+  info('template.html stats update completed');
+}
+```
+
+Step 6: Update `run()` method — change execution order:
+
+```typescript
+async run(): Promise<void> {
+  try {
+    info('Starting website data update...');
+
+    // 1. Collect all data
+    info('Reading data sources...');
+    const data = await this.collectData();
+
+    info(`Actual node count: ${data.actualNodeCount}`);
+    info(`Output file count: ${data.outputFileCount}`);
+    info(`Template count: ${data.templateCount}`);
+    info(`Community package count: ${data.communityPackageCount}`);
+    info(`n8n version: ${data.n8nVersion}`);
+    info(`Total size: ${data.totalSize}`);
+    info(`Update time: ${data.timestamp}`);
+
+    // 2. Update READMEs
+    info('Updating README.md (English)...');
+    await this.updateReadmeEn(data);
+
+    info('Updating README.zh-TW.md (Traditional Chinese)...');
+    await this.updateReadmeZhTW(data);
+
+    // 3. Update locale JSONs (data source for template)
+    info('Updating website/locales/en.json...');
+    await this.updateLocaleEn(data);
+
+    info('Updating website/locales/zh-TW.json...');
+    await this.updateLocaleZhTW(data);
+
+    // 4. Update template stats and community packages
+    info('Updating template stats...');
+    await this.updateTemplateStats(data);
+
+    info('Updating community packages in template...');
+    await this.updateCommunityPackages();
+
+    // 5. Generate localized HTML pages from template
+    info('Generating localized pages...');
+    await this.generateLocalizedPages();
+
+    // 6. Update sitemap
+    info('Updating website/sitemap.xml...');
+    await this.updateSitemap(data.timestamp);
+
+    success('Website data update completed');
+  } catch (err) {
+    logError('Website data update failed', err);
+    process.exit(1);
+  }
+}
+```
+
+Step 7: Commit
+
+```bash
+git add scripts/update-website.ts
+git commit -m "feat(website): add static multilingual page generation to update-website"
+```
+
+---
+
+### Task 6: Update robots.txt
+
+Files:
+- Modify: `website/robots.txt`
+
+Step 1: Update `website/robots.txt`:
+
+```
+User-agent: *
+Allow: /
+
+Sitemap: https://n8n-skills.frankchen.tw/sitemap.xml
+```
+
+Step 2: Commit
+
+```bash
+git add website/robots.txt
+git commit -m "chore(website): update robots.txt with new domain"
+```
+
+---
+
+### Task 7: Add hero-title-sub CSS and verify
+
+Files:
+- Modify: `website/styles.css`
+
+Step 1: Add CSS for the new H1 structure. Find the `.hero-title` rule and add after it:
+
+```css
+.hero-title-separator {
+    font-weight: 300;
+}
+
+.hero-title-sub {
+    font-size: 0.5em;
+    font-weight: 400;
+    display: block;
+}
+```
+
+Step 2: Build and verify
+
+```bash
+npm run build && npm run update:website
+```
+
+Expected: No errors. Check generated files:
+```bash
+# Verify English version exists and has correct lang
+head -5 website/index.html
+# Expected: <html lang="en">
+
+# Verify Chinese version exists
+head -5 website/zh-TW/index.html
+# Expected: <html lang="zh-TW">
+
+# Verify no unresolved placeholders
+grep -c '{{' website/index.html
+# Expected: 0
+
+grep -c '{{' website/zh-TW/index.html
+# Expected: 0
+
+# Verify no data-i18n attributes in generated files
+grep -c 'data-i18n' website/index.html
+# Expected: 0
+
+# Verify hreflang tags
+grep 'hreflang' website/index.html
+# Expected: 3 lines (en, zh-TW, x-default)
+
+# Verify sitemap has 2 URLs
+grep -c '<loc>' website/sitemap.xml
+# Expected: 2
+```
+
+Step 3: Commit
+
+```bash
+git add website/styles.css website/index.html website/zh-TW/index.html website/sitemap.xml
+git commit -m "feat(website): generate static multilingual pages with SEO improvements"
+```

--- a/scripts/update-website.ts
+++ b/scripts/update-website.ts
@@ -47,6 +47,31 @@ class WebsiteUpdater {
   private outputDir: string;
   private websiteDir: string;
 
+  private readonly SITE_DOMAIN = 'https://n8n-skills.frankchen.tw';
+
+  private readonly localeConfigs: Array<{
+    lang: string;
+    outputPath: string;
+    basePath: string;
+    ogLocale: string;
+    altLangLabel: string;
+  }> = [
+    {
+      lang: 'en',
+      outputPath: 'index.html',
+      basePath: './',
+      ogLocale: 'en_US',
+      altLangLabel: '中文',
+    },
+    {
+      lang: 'zh-TW',
+      outputPath: 'zh-TW/index.html',
+      basePath: '../',
+      ogLocale: 'zh_TW',
+      altLangLabel: 'English',
+    },
+  ];
+
   constructor() {
     this.outputDir = path.join(process.cwd(), 'output');
     this.websiteDir = path.join(process.cwd(), 'website');
@@ -68,25 +93,32 @@ class WebsiteUpdater {
       info(`Total size: ${data.totalSize}`);
       info(`Update time: ${data.timestamp}`);
 
-      // 2. Update all files
+      // 2. Update READMEs
       info('Updating README.md (English)...');
       await this.updateReadmeEn(data);
 
       info('Updating README.zh-TW.md (Traditional Chinese)...');
       await this.updateReadmeZhTW(data);
 
+      // 3. Update locale JSONs (data source for template)
       info('Updating website/locales/en.json...');
       await this.updateLocaleEn(data);
 
       info('Updating website/locales/zh-TW.json...');
       await this.updateLocaleZhTW(data);
 
-      info('Updating website/index.html...');
-      await this.updateIndexHtml(data);
+      // 4. Update template stats and community packages
+      info('Updating template stats...');
+      await this.updateTemplateStats(data);
 
-      info('Updating community packages list...');
+      info('Updating community packages in template...');
       await this.updateCommunityPackages();
 
+      // 5. Generate localized HTML pages from template
+      info('Generating localized pages...');
+      await this.generateLocalizedPages();
+
+      // 6. Update sitemap
       info('Updating website/sitemap.xml...');
       await this.updateSitemap(data.timestamp);
 
@@ -412,108 +444,111 @@ class WebsiteUpdater {
     }
   }
 
-  private async updateIndexHtml(data: UpdateData): Promise<void> {
-    try {
-      const indexPath = path.join(this.websiteDir, 'index.html');
-      let content = await fs.readFile(indexPath, 'utf-8');
+  private async generateLocalizedPages(): Promise<void> {
+    const templatePath = path.join(this.websiteDir, 'template.html');
+    const template = await fs.readFile(templatePath, 'utf-8');
 
-      const updateDate = data.timestamp.split('T')[0];
+    for (const config of this.localeConfigs) {
+      const localePath = path.join(this.websiteDir, 'locales', `${config.lang}.json`);
+      const localeContent = await fs.readFile(localePath, 'utf-8');
+      const locale = JSON.parse(localeContent);
 
-      // Update statistics cards - these are hardcoded numbers, not i18n
-      // Note: Most text content is handled by i18n (locale JSON files),
-      // but the stat numbers are direct HTML content
-      // We match using data-i18n attributes since the actual text is loaded dynamically
+      // Build special variables
+      const canonical = config.lang === 'en'
+        ? `${this.SITE_DOMAIN}/`
+        : `${this.SITE_DOMAIN}/zh-TW/`;
+      const altLangUrl = config.lang === 'en'
+        ? `${this.SITE_DOMAIN}/zh-TW/`
+        : `${this.SITE_DOMAIN}/`;
 
-      // 1. Update node count in statistics card (data-i18n="stats.nodes")
-      content = content.replace(
-        /(<div class="stat-number">)\d+(<\/div>\s*<div class="stat-label"[^>]*data-i18n="stats\.nodes")/s,
-        `$1${data.actualNodeCount}$2`
-      );
+      const specialVars: Record<string, string> = {
+        '__lang__': config.lang,
+        '__canonical__': canonical,
+        '__base_path__': config.basePath,
+        '__og_locale__': config.ogLocale,
+        '__alt_lang_url__': altLangUrl,
+        '__alt_lang_label__': config.altLangLabel,
+      };
 
-      // 2. Update template count in statistics card (data-i18n="stats.templates")
-      content = content.replace(
-        /(<div class="stat-number">)\d+(<\/div>\s*<div class="stat-label"[^>]*data-i18n="stats\.templates")/s,
-        `$1${data.templateCount}$2`
-      );
+      // Replace placeholders
+      let html = template;
 
-      // 3. Update fallback content for i18n elements (optional, will be overridden by i18n)
-      // These provide default text before i18n loads
+      // Replace special variables first
+      for (const [key, value] of Object.entries(specialVars)) {
+        html = html.replace(new RegExp(`\\{\\{${key}\\}\\}`, 'g'), value);
+      }
 
-      // Update meta descriptions
-      content = content.replace(
-        /包含 \d+ 個節點的完整知識庫/g,
-        `包含 ${data.actualNodeCount} 個節點的完整知識庫`
-      );
+      // Replace locale variables (supports nested keys like {{meta.title}})
+      html = html.replace(/\{\{([a-zA-Z][a-zA-Z0-9_.]*)\}\}/g, (_match, keyPath: string) => {
+        const keys = keyPath.split('.');
+        let value: unknown = locale;
+        for (const k of keys) {
+          if (value && typeof value === 'object') {
+            value = (value as Record<string, unknown>)[k];
+          } else {
+            return `{{${keyPath}}}`; // Keep unresolved
+          }
+        }
+        return typeof value === 'string' ? value : `{{${keyPath}}}`;
+      });
 
-      content = content.replace(
-        /Complete knowledge base with \d+ nodes/g,
-        `Complete knowledge base with ${data.actualNodeCount} nodes`
-      );
-
-      // Update hero description
-      content = content.replace(
-        />\d+ 個節點的完整知識庫，定期更新/,
-        `>${data.actualNodeCount} 個節點的完整知識庫，定期更新`
-      );
-
-      // Update feature descriptions
-      content = content.replace(
-        /包含 \d+ 個 n8n 節點的詳細文件/,
-        `包含 ${data.actualNodeCount} 個 n8n 節點的詳細文件`
-      );
-
-      content = content.replace(
-        /Detailed documentation for \d+ n8n nodes/,
-        `Detailed documentation for ${data.actualNodeCount} n8n nodes`
-      );
-
-      content = content.replace(
-        /支援最新的 n8n v[\d.]+/,
-        `支援最新的 n8n v${data.n8nVersion}`
-      );
-
-      content = content.replace(
-        /supports the latest n8n v[\d.]+/i,
-        `supports the latest n8n v${data.n8nVersion}`
-      );
-
-      // Update footer
-      content = content.replace(
-        /支援 n8n v[\d.]+ \| 最後更新：\d{4}-\d{2}-\d{2}/,
-        `支援 n8n v${data.n8nVersion} | 最後更新：${updateDate}`
-      );
-
-      content = content.replace(
-        /Supports n8n v[\d.]+ \| Last updated: \d{4}-\d{2}-\d{2}/,
-        `Supports n8n v${data.n8nVersion} | Last updated: ${updateDate}`
-      );
-
-      await fs.writeFile(indexPath, content, 'utf-8');
-      info('index.html update completed');
-    } catch (err) {
-      throw new Error(`Failed to update index.html: ${err}`);
+      // Ensure output directory exists
+      const outputPath = path.join(this.websiteDir, config.outputPath);
+      await fs.mkdir(path.dirname(outputPath), { recursive: true });
+      await fs.writeFile(outputPath, html, 'utf-8');
+      info(`Generated ${config.outputPath} (${config.lang})`);
     }
   }
 
+  private async updateTemplateStats(data: UpdateData): Promise<void> {
+    const templatePath = path.join(this.websiteDir, 'template.html');
+    let content = await fs.readFile(templatePath, 'utf-8');
+
+    // Update node count stat card
+    content = content.replace(
+      /(<div class="stat-number">)\d+(<\/div>\s*<div class="stat-label">{{stats\.nodes}})/s,
+      `$1${data.actualNodeCount}$2`
+    );
+
+    // Update template count stat card
+    content = content.replace(
+      /(<div class="stat-number">)\d+(<\/div>\s*<div class="stat-label">{{stats\.templates}})/s,
+      `$1${data.templateCount}$2`
+    );
+
+    // Update community packages count stat card
+    content = content.replace(
+      /(<div class="stat-number">)\d+(<\/div>\s*<div class="stat-label">{{stats\.communityPackages}})/s,
+      `$1${data.communityPackageCount}$2`
+    );
+
+    await fs.writeFile(templatePath, content, 'utf-8');
+    info('template.html stats update completed');
+  }
+
   private async updateSitemap(timestamp: string): Promise<void> {
-    try {
-      const sitemapPath = path.join(this.websiteDir, 'sitemap.xml');
-      let content = await fs.readFile(sitemapPath, 'utf-8');
+    const sitemapPath = path.join(this.websiteDir, 'sitemap.xml');
+    const lastmod = timestamp.split('T')[0];
 
-      // Format timestamp for sitemap format (YYYY-MM-DD)
-      const lastmod = timestamp.split('T')[0];
+    const content = `<?xml version="1.0" encoding="UTF-8"?>
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+    <url>
+        <loc>${this.SITE_DOMAIN}/</loc>
+        <lastmod>${lastmod}</lastmod>
+        <changefreq>weekly</changefreq>
+        <priority>1.0</priority>
+    </url>
+    <url>
+        <loc>${this.SITE_DOMAIN}/zh-TW/</loc>
+        <lastmod>${lastmod}</lastmod>
+        <changefreq>weekly</changefreq>
+        <priority>0.9</priority>
+    </url>
+</urlset>
+`;
 
-      // Update lastmod
-      content = content.replace(
-        /<lastmod>[\d-]+<\/lastmod>/g,
-        `<lastmod>${lastmod}</lastmod>`
-      );
-
-      await fs.writeFile(sitemapPath, content, 'utf-8');
-      info('sitemap.xml update completed');
-    } catch (err) {
-      throw new Error(`Failed to update sitemap.xml: ${err}`);
-    }
+    await fs.writeFile(sitemapPath, content, 'utf-8');
+    info('sitemap.xml update completed');
   }
 
   private async readCommunityPackages(): Promise<CommunityPackagesConfig> {
@@ -561,8 +596,8 @@ class WebsiteUpdater {
 
   private async updateCommunityPackages(): Promise<void> {
     try {
-      const indexPath = path.join(this.websiteDir, 'index.html');
-      let content = await fs.readFile(indexPath, 'utf-8');
+      const templatePath = path.join(this.websiteDir, 'template.html');
+      let content = await fs.readFile(templatePath, 'utf-8');
 
       const communityConfig = await this.readCommunityPackages();
       const packages = communityConfig.packages;
@@ -582,13 +617,7 @@ ${packagesHtml}
 
       content = content.replace(listPattern, replacement);
 
-      // Update community packages count in stats card
-      content = content.replace(
-        /(<div class="stat-number">)\d+(<\/div>\s*<div class="stat-label"[^>]*data-i18n="stats\.communityPackages")/s,
-        `$1${packages.length}$2`
-      );
-
-      await fs.writeFile(indexPath, content, 'utf-8');
+      await fs.writeFile(templatePath, content, 'utf-8');
       info('Community packages list update completed');
     } catch (err) {
       throw new Error(`Failed to update community packages: ${err}`);

--- a/scripts/update-website.ts
+++ b/scripts/update-website.ts
@@ -467,6 +467,7 @@ class WebsiteUpdater {
         '__base_path__': config.basePath,
         '__og_locale__': config.ogLocale,
         '__alt_lang_url__': altLangUrl,
+        '__alt_lang_path__': config.lang === 'en' ? '/zh-TW/' : '/',
         '__alt_lang_label__': config.altLangLabel,
       };
 

--- a/website/i18n.js
+++ b/website/i18n.js
@@ -1,192 +1,21 @@
-// Simple i18n implementation for n8n Skills website
-class I18n {
-  constructor() {
-    this.currentLang = this.detectLanguage();
-    this.translations = {};
-    this.fallbackLang = 'en';
-    // Auto-detect base path for subpath deployments
-    this.basePath = this.getBasePath();
+// Language switcher — detects current language from URL path
+(function() {
+  function getCurrentLang() {
+    return window.location.pathname.includes('/zh-TW') ? 'zh-TW' : 'en';
   }
 
-  // Get base path from current location
-  getBasePath() {
-    const pathname = window.location.pathname;
-    // If pathname ends with / or .html, get the directory path
-    const lastSlashIndex = pathname.lastIndexOf('/');
-    return pathname.substring(0, lastSlashIndex + 1);
-  }
-
-  // Detect user's preferred language
-  detectLanguage() {
-    // Check localStorage first
-    const savedLang = localStorage.getItem('n8n-skills-lang');
-    if (savedLang && ['zh-TW', 'en'].includes(savedLang)) {
-      return savedLang;
-    }
-
-    // Default to English
-    return 'en';
-  }
-
-  // Load translations for a specific language
-  async loadTranslations(lang) {
-    try {
-      const response = await fetch(`${this.basePath}locales/${lang}.json`);
-      if (!response.ok) {
-        throw new Error(`Failed to load ${lang} translations`);
-      }
-      this.translations[lang] = await response.json();
-      return true;
-    } catch (error) {
-      console.error(`Error loading translations for ${lang}:`, error);
-      return false;
+  function getAltUrl() {
+    const loc = window.location;
+    if (getCurrentLang() === 'zh-TW') {
+      // Remove /zh-TW/ from path
+      return loc.origin + loc.pathname.replace(/\/zh-TW\/?/, '/') + loc.search + loc.hash;
+    } else {
+      // Add /zh-TW/ before trailing path
+      const base = loc.pathname.replace(/\/$/, '');
+      return loc.origin + base + '/zh-TW/' + loc.search + loc.hash;
     }
   }
 
-  // Get nested translation value by key path (e.g., "hero.title")
-  t(keyPath) {
-    const keys = keyPath.split('.');
-    let value = this.translations[this.currentLang];
-
-    for (const key of keys) {
-      if (value && typeof value === 'object') {
-        value = value[key];
-      } else {
-        break;
-      }
-    }
-
-    // Fallback to English if translation not found
-    if (value === undefined && this.currentLang !== this.fallbackLang) {
-      value = this.translations[this.fallbackLang];
-      for (const key of keys) {
-        if (value && typeof value === 'object') {
-          value = value[key];
-        } else {
-          break;
-        }
-      }
-    }
-
-    return value || keyPath;
-  }
-
-  // Update all elements with data-i18n attribute
-  updatePageContent() {
-    // Update text content
-    document.querySelectorAll('[data-i18n]').forEach(element => {
-      const key = element.getAttribute('data-i18n');
-      element.textContent = this.t(key);
-    });
-
-    // Update aria-label attributes
-    document.querySelectorAll('[data-i18n-aria]').forEach(element => {
-      const key = element.getAttribute('data-i18n-aria');
-      element.setAttribute('aria-label', this.t(key));
-    });
-
-    // Update meta tags
-    this.updateMetaTags();
-
-    // Update HTML lang attribute
-    document.documentElement.setAttribute('lang', this.currentLang);
-  }
-
-  // Update meta tags for SEO
-  updateMetaTags() {
-    const metaTitle = this.t('meta.title');
-    const metaDescription = this.t('meta.description');
-    const metaKeywords = this.t('meta.keywords');
-
-    // Update title
-    document.title = metaTitle;
-
-    // Update meta tags
-    this.updateMetaTag('name', 'title', metaTitle);
-    this.updateMetaTag('name', 'description', metaDescription);
-    this.updateMetaTag('name', 'keywords', metaKeywords);
-
-    // Update Open Graph tags
-    this.updateMetaTag('property', 'og:title', metaTitle);
-    this.updateMetaTag('property', 'og:description', metaDescription);
-    this.updateMetaTag('property', 'og:locale', this.currentLang === 'zh-TW' ? 'zh_TW' : 'en_US');
-
-    // Update Twitter tags
-    this.updateMetaTag('property', 'twitter:title', metaTitle);
-    this.updateMetaTag('property', 'twitter:description', metaDescription);
-
-    // Update JSON-LD structured data
-    const jsonLdScript = document.querySelector('script[type="application/ld+json"]');
-    if (jsonLdScript) {
-      try {
-        const structuredData = JSON.parse(jsonLdScript.textContent);
-        structuredData.description = metaDescription;
-        jsonLdScript.textContent = JSON.stringify(structuredData, null, 2);
-      } catch (e) {
-        console.error('Error updating JSON-LD:', e);
-      }
-    }
-  }
-
-  // Helper function to update meta tag
-  updateMetaTag(attribute, name, content) {
-    let element = document.querySelector(`meta[${attribute}="${name}"]`);
-    if (!element) {
-      element = document.createElement('meta');
-      element.setAttribute(attribute, name);
-      document.head.appendChild(element);
-    }
-    element.setAttribute('content', content);
-  }
-
-  // Switch language
-  async switchLanguage(lang) {
-    if (!['zh-TW', 'en'].includes(lang)) {
-      console.error(`Unsupported language: ${lang}`);
-      return false;
-    }
-
-    // Load translations if not already loaded
-    if (!this.translations[lang]) {
-      const loaded = await this.loadTranslations(lang);
-      if (!loaded) {
-        return false;
-      }
-    }
-
-    this.currentLang = lang;
-    localStorage.setItem('n8n-skills-lang', lang);
-    this.updatePageContent();
-
-    // Trigger custom event for other components to listen
-    window.dispatchEvent(new CustomEvent('languageChanged', { detail: { lang } }));
-
-    return true;
-  }
-
-  // Initialize i18n
-  async init() {
-    // Load current language translations
-    await this.loadTranslations(this.currentLang);
-
-    // Load fallback language if different
-    if (this.currentLang !== this.fallbackLang) {
-      await this.loadTranslations(this.fallbackLang);
-    }
-
-    // Update page content
-    this.updatePageContent();
-
-    return true;
-  }
-
-  // Get current language
-  getCurrentLanguage() {
-    return this.currentLang;
-  }
-}
-
-// Export for use in other scripts
-if (typeof module !== 'undefined' && module.exports) {
-  module.exports = I18n;
-}
+  window.i18nLang = getCurrentLang();
+  window.i18nGetAltUrl = getAltUrl;
+})();

--- a/website/index.html
+++ b/website/index.html
@@ -738,6 +738,7 @@
             <!-- 底部版權 -->
             <div class="footer-bottom">
                 <p class="footer-copyright">© 2025 Frank Chen. All rights reserved.</p>
+                <p class="footer-version">Supports n8n v2.13.4 | Last updated: 2026-03-30</p>
             </div>
         </div>
     </footer>

--- a/website/index.html
+++ b/website/index.html
@@ -69,7 +69,7 @@
 
 <body>
     <!-- Fixed Language Toggle Button -->
-    <button id="lang-toggle" class="lang-toggle-fixed" onclick="window.location.href='https://n8n-skills.frankchen.tw/zh-TW/'">
+    <button id="lang-toggle" class="lang-toggle-fixed" onclick="window.location.href='/zh-TW/'">
         <span class="lang-icon">🌐</span>
         <span class="lang-text">中文</span>
     </button>
@@ -100,7 +100,7 @@
                 <div class="license-badge">
                     <span>Open Source MIT License</span>
                 </div>
-                <h1 class="hero-title">n8n Skills<span class="hero-title-separator"> — </span><span class="hero-title-sub">Turn your AI assistant into an n8n workflow expert</span></h1>
+                <h1 class="hero-title">n8n Skills<span class="hero-title-sub">Turn your AI assistant into an n8n workflow expert</span></h1>
                 <p class="hero-description">Complete knowledge base with 545 nodes, regularly updated, intelligently prioritized</p>
                 <div class="hero-buttons">
                     <a href="https://github.com/haunchen/n8n-skills" class="btn btn-primary" target="_blank"

--- a/website/locales/en.json
+++ b/website/locales/en.json
@@ -10,6 +10,10 @@
     "ariaGithub": "Visit n8n Skills GitHub repository",
     "ariaGetStarted": "Download the latest version of n8n Skills"
   },
+  "aria": {
+    "githubProject": "Visit n8n Skills GitHub repository",
+    "downloadLatest": "Download the latest version of n8n Skills"
+  },
   "hero": {
     "license": "Open Source MIT License",
     "title": "n8n Skills",

--- a/website/locales/zh-TW.json
+++ b/website/locales/zh-TW.json
@@ -10,6 +10,10 @@
     "ariaGithub": "前往 n8n Skills GitHub 專案",
     "ariaGetStarted": "下載最新版本的 n8n Skills"
   },
+  "aria": {
+    "githubProject": "前往 n8n Skills GitHub 專案",
+    "downloadLatest": "下載最新版本的 n8n Skills"
+  },
   "hero": {
     "license": "Open Source MIT License",
     "title": "n8n Skills",

--- a/website/robots.txt
+++ b/website/robots.txt
@@ -1,4 +1,4 @@
 User-agent: *
 Allow: /
 
-Sitemap: https://www.frankchen.tw/n8n-skills/sitemap.xml
+Sitemap: https://n8n-skills.frankchen.tw/sitemap.xml

--- a/website/script.js
+++ b/website/script.js
@@ -1,34 +1,8 @@
 // Scroll-based navbar control
-document.addEventListener('DOMContentLoaded', async function() {
+document.addEventListener('DOMContentLoaded', function() {
     const navbar = document.getElementById('navbar');
     const heroButtons = document.querySelector('.hero-buttons');
     const heroTitle = document.querySelector('.hero-title');
-
-    // Initialize i18n as global variable
-    window.i18n = new I18n();
-    await window.i18n.init();
-
-    // Update language toggle button text
-    updateLangToggleButton(window.i18n.getCurrentLanguage());
-
-    // Setup language toggle
-    const langToggle = document.getElementById('lang-toggle');
-    if (langToggle) {
-        langToggle.addEventListener('click', async function() {
-            const currentLang = window.i18n.getCurrentLanguage();
-            const newLang = currentLang === 'zh-TW' ? 'en' : 'zh-TW';
-            await window.i18n.switchLanguage(newLang);
-            updateLangToggleButton(newLang);
-        });
-    }
-
-    // Update language toggle button text
-    function updateLangToggleButton(lang) {
-        const langText = document.querySelector('.lang-text');
-        if (langText) {
-            langText.textContent = lang === 'zh-TW' ? '中' : 'En';
-        }
-    }
 
     // Use Intersection Observer to monitor button area
     const observerOptions = {
@@ -90,45 +64,6 @@ function initCommunityPackages() {
             section.scrollIntoView({ behavior: 'smooth', block: 'start' });
         });
     }
-
-    // Update category labels based on current language
-    if (window.i18n) {
-        updateCategoryLabels();
-        // Listen for language changes
-        document.addEventListener('languageChanged', updateCategoryLabels);
-    }
-}
-
-// Update category labels with translations
-function updateCategoryLabels() {
-    const categoryLabels = {
-        'en': {
-            'communication': 'Communication',
-            'ai-tools': 'AI Tools',
-            'web-scraping': 'Web Scraping',
-            'document': 'Document',
-            'data-processing': 'Data Processing',
-            'utilities': 'Utilities'
-        },
-        'zh-TW': {
-            'communication': '通訊',
-            'ai-tools': 'AI 工具',
-            'web-scraping': '網頁爬蟲',
-            'document': '文件處理',
-            'data-processing': '資料處理',
-            'utilities': '實用工具'
-        }
-    };
-
-    const currentLang = window.i18n ? window.i18n.getCurrentLanguage() : 'zh-TW';
-    const labels = categoryLabels[currentLang] || categoryLabels['en'];
-
-    document.querySelectorAll('.package-category[data-category]').forEach(el => {
-        const category = el.getAttribute('data-category');
-        if (labels[category]) {
-            el.textContent = labels[category];
-        }
-    });
 }
 
 // Copy button functionality

--- a/website/sitemap.xml
+++ b/website/sitemap.xml
@@ -2,13 +2,13 @@
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
     <url>
         <loc>https://n8n-skills.frankchen.tw/</loc>
-        <lastmod>2025-12-30</lastmod>
+        <lastmod>2026-03-30</lastmod>
         <changefreq>weekly</changefreq>
         <priority>1.0</priority>
     </url>
     <url>
         <loc>https://n8n-skills.frankchen.tw/zh-TW/</loc>
-        <lastmod>2025-12-30</lastmod>
+        <lastmod>2026-03-30</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.9</priority>
     </url>

--- a/website/sitemap.xml
+++ b/website/sitemap.xml
@@ -1,9 +1,15 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
     <url>
-        <loc>https://www.frankchen.tw/n8n-skills/</loc>
-        <lastmod>2026-03-30</lastmod>
+        <loc>https://n8n-skills.frankchen.tw/</loc>
+        <lastmod>2025-12-30</lastmod>
         <changefreq>weekly</changefreq>
         <priority>1.0</priority>
+    </url>
+    <url>
+        <loc>https://n8n-skills.frankchen.tw/zh-TW/</loc>
+        <lastmod>2025-12-30</lastmod>
+        <changefreq>weekly</changefreq>
+        <priority>0.9</priority>
     </url>
 </urlset>

--- a/website/styles.css
+++ b/website/styles.css
@@ -84,6 +84,16 @@ body {
     background-clip: text;
 }
 
+.hero-title-separator {
+    font-weight: 300;
+}
+
+.hero-title-sub {
+    font-size: 0.5em;
+    font-weight: 400;
+    display: block;
+}
+
 .hero-subtitle {
     font-size: 1.75rem;
     margin-bottom: 1rem;

--- a/website/styles.css
+++ b/website/styles.css
@@ -84,10 +84,6 @@ body {
     background-clip: text;
 }
 
-.hero-title-separator {
-    font-weight: 300;
-}
-
 .hero-title-sub {
     font-size: 0.5em;
     font-weight: 400;

--- a/website/template.html
+++ b/website/template.html
@@ -738,6 +738,7 @@
             <!-- 底部版權 -->
             <div class="footer-bottom">
                 <p class="footer-copyright">{{footer.copyright}}</p>
+                <p class="footer-version">{{footer.version}}</p>
             </div>
         </div>
     </footer>

--- a/website/template.html
+++ b/website/template.html
@@ -69,7 +69,7 @@
 
 <body>
     <!-- Fixed Language Toggle Button -->
-    <button id="lang-toggle" class="lang-toggle-fixed" onclick="window.location.href='{{__alt_lang_url__}}'">
+    <button id="lang-toggle" class="lang-toggle-fixed" onclick="window.location.href='{{__alt_lang_path__}}'">
         <span class="lang-icon">🌐</span>
         <span class="lang-text">{{__alt_lang_label__}}</span>
     </button>
@@ -100,7 +100,7 @@
                 <div class="license-badge">
                     <span>Open Source MIT License</span>
                 </div>
-                <h1 class="hero-title">n8n Skills<span class="hero-title-separator"> — </span><span class="hero-title-sub">{{hero.subtitle}}</span></h1>
+                <h1 class="hero-title">n8n Skills<span class="hero-title-sub">{{hero.subtitle}}</span></h1>
                 <p class="hero-description">{{hero.description}}</p>
                 <div class="hero-buttons">
                     <a href="https://github.com/haunchen/n8n-skills" class="btn btn-primary" target="_blank"

--- a/website/template.html
+++ b/website/template.html
@@ -1,0 +1,748 @@
+<!DOCTYPE html>
+<html lang="{{__lang__}}">
+
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+
+    <!-- Primary Meta Tags -->
+    <title>{{meta.title}}</title>
+    <meta name="title" content="{{meta.title}}">
+    <meta name="description" content="{{meta.description}}">
+    <meta name="keywords" content="{{meta.keywords}}">
+    <meta name="author" content="Frank Chen">
+    <meta name="robots" content="index, follow">
+    <link rel="canonical" href="{{__canonical__}}">
+    <link rel="icon" href="{{__base_path__}}assets/n8n-skills-icon.png">
+
+    <!-- Hreflang -->
+    <link rel="alternate" hreflang="en" href="https://n8n-skills.frankchen.tw/">
+    <link rel="alternate" hreflang="zh-TW" href="https://n8n-skills.frankchen.tw/zh-TW/">
+    <link rel="alternate" hreflang="x-default" href="https://n8n-skills.frankchen.tw/">
+
+    <!-- Open Graph / Facebook -->
+    <meta property="og:type" content="website">
+    <meta property="og:url" content="{{__canonical__}}">
+    <meta property="og:title" content="{{meta.title}}">
+    <meta property="og:description" content="{{meta.description}}">
+    <meta property="og:locale" content="{{__og_locale__}}">
+    <meta property="og:image" content="https://n8n-skills.frankchen.tw/assets/n8n-skills-icon.png">
+
+    <!-- Twitter -->
+    <meta property="twitter:card" content="summary_large_image">
+    <meta property="twitter:url" content="{{__canonical__}}">
+    <meta property="twitter:title" content="{{meta.title}}">
+    <meta property="twitter:description" content="{{meta.description}}">
+    <meta property="twitter:image" content="https://n8n-skills.frankchen.tw/assets/n8n-skills-icon.png">
+
+    <!-- Theme Color -->
+    <meta name="theme-color" content="#0f172a">
+
+    <!-- Preconnect to external domains -->
+    <link rel="preconnect" href="https://github.com" crossorigin>
+
+    <link rel="stylesheet" href="{{__base_path__}}styles.css">
+    <script src="{{__base_path__}}i18n.js"></script>
+
+    <!-- Structured Data (JSON-LD) -->
+    <script type="application/ld+json">
+    {
+      "@context": "https://schema.org",
+      "@type": "SoftwareApplication",
+      "name": "n8n Skills",
+      "applicationCategory": "DeveloperApplication",
+      "offers": {
+        "@type": "Offer",
+        "price": "0",
+        "priceCurrency": "USD"
+      },
+      "operatingSystem": "Cross-platform",
+      "description": "{{meta.description}}",
+      "author": {
+        "@type": "Person",
+        "name": "Frank Chen"
+      },
+      "url": "https://n8n-skills.frankchen.tw/"
+    }
+    </script>
+</head>
+
+<body>
+    <!-- Fixed Language Toggle Button -->
+    <button id="lang-toggle" class="lang-toggle-fixed" onclick="window.location.href='{{__alt_lang_url__}}'">
+        <span class="lang-icon">🌐</span>
+        <span class="lang-text">{{__alt_lang_label__}}</span>
+    </button>
+
+    <!-- Sticky Navbar -->
+    <nav id="navbar" class="navbar">
+        <div class="navbar-container">
+            <div class="navbar-brand">n8n Skills</div>
+            <div class="navbar-buttons">
+                <a href="https://github.com/haunchen/n8n-skills" class="btn btn-primary btn-nav" target="_blank"
+                    rel="noopener noreferrer" aria-label="{{aria.githubProject}}">
+                    <svg width="20" height="20" fill="currentColor" viewBox="0 0 16 16" aria-hidden="true">
+                        <path
+                            d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27.68 0 1.36.09 2 .27 1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.012 8.012 0 0 0 16 8c0-4.42-3.58-8-8-8z" />
+                    </svg>
+                    GitHub
+                </a>
+                <a href="https://github.com/haunchen/n8n-skills/releases" class="btn btn-secondary btn-nav"
+                    target="_blank" rel="noopener noreferrer" aria-label="{{aria.downloadLatest}}">{{nav.getStarted}}</a>
+            </div>
+        </div>
+    </nav>
+
+    <!-- Hero Section -->
+    <section class="hero">
+        <div class="container">
+            <div class="hero-content">
+                <div class="license-badge">
+                    <span>Open Source MIT License</span>
+                </div>
+                <h1 class="hero-title">n8n Skills<span class="hero-title-separator"> — </span><span class="hero-title-sub">{{hero.subtitle}}</span></h1>
+                <p class="hero-description">{{hero.description}}</p>
+                <div class="hero-buttons">
+                    <a href="https://github.com/haunchen/n8n-skills" class="btn btn-primary" target="_blank"
+                        rel="noopener noreferrer" aria-label="{{aria.githubProject}}">
+                        <svg width="20" height="20" fill="currentColor" viewBox="0 0 16 16" aria-hidden="true">
+                            <path
+                                d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27.68 0 1.36.09 2 .27 1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.012 8.012 0 0 0 16 8c0-4.42-3.58-8-8-8z" />
+                        </svg>
+                        GitHub
+                    </a>
+                    <a href="https://github.com/haunchen/n8n-skills/releases" class="btn btn-secondary" target="_blank"
+                        rel="noopener noreferrer" aria-label="{{aria.downloadLatest}}">{{nav.getStarted}}</a>
+                </div>
+            </div>
+        </div>
+    </section>
+
+    <!-- Stats Section -->
+    <section class="stats">
+        <div class="container">
+            <div class="stats-grid">
+                <div class="stat-card">
+                    <div class="stat-number">545</div>
+                    <div class="stat-label">{{stats.nodes}}</div>
+                </div>
+                <div class="stat-card">
+                    <div class="stat-number">6</div>
+                    <div class="stat-label">{{stats.categories}}</div>
+                </div>
+                <div class="stat-card">
+                    <div class="stat-number">20</div>
+                    <div class="stat-label">{{stats.templates}}</div>
+                </div>
+                <div class="stat-card stat-card-clickable" id="community-stats-card">
+                    <div class="stat-number">30</div>
+                    <div class="stat-label">{{stats.communityPackages}}</div>
+                    <div class="stat-expand-hint">{{stats.clickToExpand}}</div>
+                </div>
+            </div>
+            <!-- Community Packages Section -->
+            <div class="community-packages-section" id="community-packages-section">
+                <div class="community-packages-header" id="community-packages-toggle">
+                    <h3 class="community-packages-title">{{community.title}}</h3>
+                    <span class="community-packages-toggle-icon">▼</span>
+                </div>
+                <div class="community-packages-content" id="community-packages-content">
+                    <!-- BEGIN COMMUNITY_PACKAGES_LIST -->
+        <div class="community-packages-grid">
+            <div class="community-package-card" data-category="communication">
+                <div class="package-header">
+                    <span class="package-name">n8n-nodes-evolution-api</span>
+                    <span class="package-category" data-category="communication">communication</span>
+                </div>
+                <p class="package-description">A Evolution API é um hub de canais com foco no WhatsApp</p>
+                <a href="https://www.npmjs.com/package/n8n-nodes-evolution-api" class="package-npm-link" target="_blank" rel="noopener noreferrer">
+                    <svg class="npm-icon" viewBox="0 0 24 24" width="16" height="16">
+                        <path fill="currentColor" d="M0 0v24h24V0H0zm19.2 19.2H12V7.2h3.6v8.4h3.6V4.8H4.8v14.4h14.4v-4.8z"/>
+                    </svg>
+                    npm
+                </a>
+            </div>
+            <div class="community-package-card" data-category="utilities">
+                <div class="package-header">
+                    <span class="package-name">n8n-nodes-kommo</span>
+                    <span class="package-category" data-category="utilities">utilities</span>
+                </div>
+                <p class="package-description">n8n node for Kommo Api</p>
+                <a href="https://www.npmjs.com/package/n8n-nodes-kommo" class="package-npm-link" target="_blank" rel="noopener noreferrer">
+                    <svg class="npm-icon" viewBox="0 0 24 24" width="16" height="16">
+                        <path fill="currentColor" d="M0 0v24h24V0H0zm19.2 19.2H12V7.2h3.6v8.4h3.6V4.8H4.8v14.4h14.4v-4.8z"/>
+                    </svg>
+                    npm
+                </a>
+            </div>
+            <div class="community-package-card" data-category="ai-tools">
+                <div class="package-header">
+                    <span class="package-name">n8n-nodes-palatine-speech</span>
+                    <span class="package-category" data-category="ai-tools">ai-tools</span>
+                </div>
+                <p class="package-description">Official n8n node for Palatine Speech API: transcription, diarization, sentiment analysis, summarization and more</p>
+                <a href="https://www.npmjs.com/package/n8n-nodes-palatine-speech" class="package-npm-link" target="_blank" rel="noopener noreferrer">
+                    <svg class="npm-icon" viewBox="0 0 24 24" width="16" height="16">
+                        <path fill="currentColor" d="M0 0v24h24V0H0zm19.2 19.2H12V7.2h3.6v8.4h3.6V4.8H4.8v14.4h14.4v-4.8z"/>
+                    </svg>
+                    npm
+                </a>
+            </div>
+            <div class="community-package-card" data-category="communication">
+                <div class="package-header">
+                    <span class="package-name">n8n-nodes-waha</span>
+                    <span class="package-category" data-category="communication">communication</span>
+                </div>
+                <p class="package-description">n8n to connect with WAHA (Whatsapp HTTP API)</p>
+                <a href="https://www.npmjs.com/package/n8n-nodes-waha" class="package-npm-link" target="_blank" rel="noopener noreferrer">
+                    <svg class="npm-icon" viewBox="0 0 24 24" width="16" height="16">
+                        <path fill="currentColor" d="M0 0v24h24V0H0zm19.2 19.2H12V7.2h3.6v8.4h3.6V4.8H4.8v14.4h14.4v-4.8z"/>
+                    </svg>
+                    npm
+                </a>
+            </div>
+            <div class="community-package-card" data-category="web-scraping">
+                <div class="package-header">
+                    <span class="package-name">n8n-nodes-serpapi</span>
+                    <span class="package-category" data-category="web-scraping">web-scraping</span>
+                </div>
+                <p class="package-description">Official n8n node for SerpApi</p>
+                <a href="https://www.npmjs.com/package/n8n-nodes-serpapi" class="package-npm-link" target="_blank" rel="noopener noreferrer">
+                    <svg class="npm-icon" viewBox="0 0 24 24" width="16" height="16">
+                        <path fill="currentColor" d="M0 0v24h24V0H0zm19.2 19.2H12V7.2h3.6v8.4h3.6V4.8H4.8v14.4h14.4v-4.8z"/>
+                    </svg>
+                    npm
+                </a>
+            </div>
+            <div class="community-package-card" data-category="document">
+                <div class="package-header">
+                    <span class="package-name">n8n-nodes-pdfco</span>
+                    <span class="package-category" data-category="document">document</span>
+                </div>
+                <p class="package-description">Pdf.co nodes for n8n</p>
+                <a href="https://www.npmjs.com/package/n8n-nodes-pdfco" class="package-npm-link" target="_blank" rel="noopener noreferrer">
+                    <svg class="npm-icon" viewBox="0 0 24 24" width="16" height="16">
+                        <path fill="currentColor" d="M0 0v24h24V0H0zm19.2 19.2H12V7.2h3.6v8.4h3.6V4.8H4.8v14.4h14.4v-4.8z"/>
+                    </svg>
+                    npm
+                </a>
+            </div>
+            <div class="community-package-card" data-category="utilities">
+                <div class="package-header">
+                    <span class="package-name">n8n-nodes-globals</span>
+                    <span class="package-category" data-category="utilities">utilities</span>
+                </div>
+                <p class="package-description">N8N community node that allows users to create global constants and use them in all their workflows</p>
+                <a href="https://www.npmjs.com/package/n8n-nodes-globals" class="package-npm-link" target="_blank" rel="noopener noreferrer">
+                    <svg class="npm-icon" viewBox="0 0 24 24" width="16" height="16">
+                        <path fill="currentColor" d="M0 0v24h24V0H0zm19.2 19.2H12V7.2h3.6v8.4h3.6V4.8H4.8v14.4h14.4v-4.8z"/>
+                    </svg>
+                    npm
+                </a>
+            </div>
+            <div class="community-package-card" data-category="communication">
+                <div class="package-header">
+                    <span class="package-name">n8n-nodes-chatwoot</span>
+                    <span class="package-category" data-category="communication">communication</span>
+                </div>
+                <p class="package-description">This is an n8n community node. It lets you use ChatWoot in your n8n workflows.</p>
+                <a href="https://www.npmjs.com/package/n8n-nodes-chatwoot" class="package-npm-link" target="_blank" rel="noopener noreferrer">
+                    <svg class="npm-icon" viewBox="0 0 24 24" width="16" height="16">
+                        <path fill="currentColor" d="M0 0v24h24V0H0zm19.2 19.2H12V7.2h3.6v8.4h3.6V4.8H4.8v14.4h14.4v-4.8z"/>
+                    </svg>
+                    npm
+                </a>
+            </div>
+            <div class="community-package-card" data-category="ai-tools">
+                <div class="package-header">
+                    <span class="package-name">@gotohuman/n8n-nodes-gotohuman</span>
+                    <span class="package-category" data-category="ai-tools">ai-tools</span>
+                </div>
+                <p class="package-description">n8n node to request human reviews in AI workflows with gotoHuman</p>
+                <a href="https://www.npmjs.com/package/@gotohuman/n8n-nodes-gotohuman" class="package-npm-link" target="_blank" rel="noopener noreferrer">
+                    <svg class="npm-icon" viewBox="0 0 24 24" width="16" height="16">
+                        <path fill="currentColor" d="M0 0v24h24V0H0zm19.2 19.2H12V7.2h3.6v8.4h3.6V4.8H4.8v14.4h14.4v-4.8z"/>
+                    </svg>
+                    npm
+                </a>
+            </div>
+            <div class="community-package-card" data-category="web-scraping">
+                <div class="package-header">
+                    <span class="package-name">@tavily/n8n-nodes-tavily</span>
+                    <span class="package-category" data-category="web-scraping">web-scraping</span>
+                </div>
+                <p class="package-description">A community node for n8n to integrate Tavily API for web search and content extraction.</p>
+                <a href="https://www.npmjs.com/package/@tavily/n8n-nodes-tavily" class="package-npm-link" target="_blank" rel="noopener noreferrer">
+                    <svg class="npm-icon" viewBox="0 0 24 24" width="16" height="16">
+                        <path fill="currentColor" d="M0 0v24h24V0H0zm19.2 19.2H12V7.2h3.6v8.4h3.6V4.8H4.8v14.4h14.4v-4.8z"/>
+                    </svg>
+                    npm
+                </a>
+            </div>
+            <div class="community-package-card" data-category="utilities">
+                <div class="package-header">
+                    <span class="package-name">@mookielianhd/n8n-nodes-instagram</span>
+                    <span class="package-category" data-category="utilities">utilities</span>
+                </div>
+                <p class="package-description">Instagram node for n8n</p>
+                <a href="https://www.npmjs.com/package/@mookielianhd/n8n-nodes-instagram" class="package-npm-link" target="_blank" rel="noopener noreferrer">
+                    <svg class="npm-icon" viewBox="0 0 24 24" width="16" height="16">
+                        <path fill="currentColor" d="M0 0v24h24V0H0zm19.2 19.2H12V7.2h3.6v8.4h3.6V4.8H4.8v14.4h14.4v-4.8z"/>
+                    </svg>
+                    npm
+                </a>
+            </div>
+            <div class="community-package-card" data-category="ai-tools">
+                <div class="package-header">
+                    <span class="package-name">@elevenlabs/n8n-nodes-elevenlabs</span>
+                    <span class="package-category" data-category="ai-tools">ai-tools</span>
+                </div>
+                <p class="package-description">Official ElevenLabs node for n8n</p>
+                <a href="https://www.npmjs.com/package/@elevenlabs/n8n-nodes-elevenlabs" class="package-npm-link" target="_blank" rel="noopener noreferrer">
+                    <svg class="npm-icon" viewBox="0 0 24 24" width="16" height="16">
+                        <path fill="currentColor" d="M0 0v24h24V0H0zm19.2 19.2H12V7.2h3.6v8.4h3.6V4.8H4.8v14.4h14.4v-4.8z"/>
+                    </svg>
+                    npm
+                </a>
+            </div>
+            <div class="community-package-card" data-category="ai-tools">
+                <div class="package-header">
+                    <span class="package-name">n8n-nodes-kipps</span>
+                    <span class="package-category" data-category="ai-tools">ai-tools</span>
+                </div>
+                <p class="package-description">Custom Kipps.ai integration node for n8n</p>
+                <a href="https://www.npmjs.com/package/n8n-nodes-kipps" class="package-npm-link" target="_blank" rel="noopener noreferrer">
+                    <svg class="npm-icon" viewBox="0 0 24 24" width="16" height="16">
+                        <path fill="currentColor" d="M0 0v24h24V0H0zm19.2 19.2H12V7.2h3.6v8.4h3.6V4.8H4.8v14.4h14.4v-4.8z"/>
+                    </svg>
+                    npm
+                </a>
+            </div>
+            <div class="community-package-card" data-category="utilities">
+                <div class="package-header">
+                    <span class="package-name">n8n-nodes-cronlytic</span>
+                    <span class="package-category" data-category="utilities">utilities</span>
+                </div>
+                <p class="package-description">n8n community node for Cronlytic advanced cron scheduling</p>
+                <a href="https://www.npmjs.com/package/n8n-nodes-cronlytic" class="package-npm-link" target="_blank" rel="noopener noreferrer">
+                    <svg class="npm-icon" viewBox="0 0 24 24" width="16" height="16">
+                        <path fill="currentColor" d="M0 0v24h24V0H0zm19.2 19.2H12V7.2h3.6v8.4h3.6V4.8H4.8v14.4h14.4v-4.8z"/>
+                    </svg>
+                    npm
+                </a>
+            </div>
+            <div class="community-package-card" data-category="document">
+                <div class="package-header">
+                    <span class="package-name">n8n-nodes-a2a</span>
+                    <span class="package-category" data-category="document">document</span>
+                </div>
+                <p class="package-description">n8n community node for A2A (Account to Account) transfers, account management, and Google Agent2Agent protocol communica...</p>
+                <a href="https://www.npmjs.com/package/n8n-nodes-a2a" class="package-npm-link" target="_blank" rel="noopener noreferrer">
+                    <svg class="npm-icon" viewBox="0 0 24 24" width="16" height="16">
+                        <path fill="currentColor" d="M0 0v24h24V0H0zm19.2 19.2H12V7.2h3.6v8.4h3.6V4.8H4.8v14.4h14.4v-4.8z"/>
+                    </svg>
+                    npm
+                </a>
+            </div>
+            <div class="community-package-card" data-category="utilities">
+                <div class="package-header">
+                    <span class="package-name">n8n-nodes-rd-station-crm</span>
+                    <span class="package-category" data-category="utilities">utilities</span>
+                </div>
+                <p class="package-description">Nós personalizados do n8n para integração com a API do RD Station CRM (v1)</p>
+                <a href="https://www.npmjs.com/package/n8n-nodes-rd-station-crm" class="package-npm-link" target="_blank" rel="noopener noreferrer">
+                    <svg class="npm-icon" viewBox="0 0 24 24" width="16" height="16">
+                        <path fill="currentColor" d="M0 0v24h24V0H0zm19.2 19.2H12V7.2h3.6v8.4h3.6V4.8H4.8v14.4h14.4v-4.8z"/>
+                    </svg>
+                    npm
+                </a>
+            </div>
+            <div class="community-package-card" data-category="ai-tools">
+                <div class="package-header">
+                    <span class="package-name">n8n-nodes-mcp</span>
+                    <span class="package-category" data-category="ai-tools">ai-tools</span>
+                </div>
+                <p class="package-description">MCP nodes for n8n </p>
+                <a href="https://www.npmjs.com/package/n8n-nodes-mcp" class="package-npm-link" target="_blank" rel="noopener noreferrer">
+                    <svg class="npm-icon" viewBox="0 0 24 24" width="16" height="16">
+                        <path fill="currentColor" d="M0 0v24h24V0H0zm19.2 19.2H12V7.2h3.6v8.4h3.6V4.8H4.8v14.4h14.4v-4.8z"/>
+                    </svg>
+                    npm
+                </a>
+            </div>
+            <div class="community-package-card" data-category="communication">
+                <div class="package-header">
+                    <span class="package-name">@devlikeapro/n8n-nodes-chatwoot</span>
+                    <span class="package-category" data-category="communication">communication</span>
+                </div>
+                <p class="package-description">n8n node to connect with ChatWoot</p>
+                <a href="https://www.npmjs.com/package/@devlikeapro/n8n-nodes-chatwoot" class="package-npm-link" target="_blank" rel="noopener noreferrer">
+                    <svg class="npm-icon" viewBox="0 0 24 24" width="16" height="16">
+                        <path fill="currentColor" d="M0 0v24h24V0H0zm19.2 19.2H12V7.2h3.6v8.4h3.6V4.8H4.8v14.4h14.4v-4.8z"/>
+                    </svg>
+                    npm
+                </a>
+            </div>
+            <div class="community-package-card" data-category="utilities">
+                <div class="package-header">
+                    <span class="package-name">n8n-nodes-powerbi</span>
+                    <span class="package-category" data-category="utilities">utilities</span>
+                </div>
+                <p class="package-description">n8n nodes for integration with Power BI APIs</p>
+                <a href="https://www.npmjs.com/package/n8n-nodes-powerbi" class="package-npm-link" target="_blank" rel="noopener noreferrer">
+                    <svg class="npm-icon" viewBox="0 0 24 24" width="16" height="16">
+                        <path fill="currentColor" d="M0 0v24h24V0H0zm19.2 19.2H12V7.2h3.6v8.4h3.6V4.8H4.8v14.4h14.4v-4.8z"/>
+                    </svg>
+                    npm
+                </a>
+            </div>
+            <div class="community-package-card" data-category="document">
+                <div class="package-header">
+                    <span class="package-name">n8n-nodes-docx-converter</span>
+                    <span class="package-category" data-category="document">document</span>
+                </div>
+                <p class="package-description">A node to convert Docx to Text</p>
+                <a href="https://www.npmjs.com/package/n8n-nodes-docx-converter" class="package-npm-link" target="_blank" rel="noopener noreferrer">
+                    <svg class="npm-icon" viewBox="0 0 24 24" width="16" height="16">
+                        <path fill="currentColor" d="M0 0v24h24V0H0zm19.2 19.2H12V7.2h3.6v8.4h3.6V4.8H4.8v14.4h14.4v-4.8z"/>
+                    </svg>
+                    npm
+                </a>
+            </div>
+            <div class="community-package-card" data-category="data-processing">
+                <div class="package-header">
+                    <span class="package-name">n8n-nodes-notionmd</span>
+                    <span class="package-category" data-category="data-processing">data-processing</span>
+                </div>
+                <p class="package-description">n8n node to transform markdown to notion blocks</p>
+                <a href="https://www.npmjs.com/package/n8n-nodes-notionmd" class="package-npm-link" target="_blank" rel="noopener noreferrer">
+                    <svg class="npm-icon" viewBox="0 0 24 24" width="16" height="16">
+                        <path fill="currentColor" d="M0 0v24h24V0H0zm19.2 19.2H12V7.2h3.6v8.4h3.6V4.8H4.8v14.4h14.4v-4.8z"/>
+                    </svg>
+                    npm
+                </a>
+            </div>
+            <div class="community-package-card" data-category="web-scraping">
+                <div class="package-header">
+                    <span class="package-name">n8n-nodes-puppeteer</span>
+                    <span class="package-category" data-category="web-scraping">web-scraping</span>
+                </div>
+                <p class="package-description">n8n node for browser automation using Puppeteer</p>
+                <a href="https://www.npmjs.com/package/n8n-nodes-puppeteer" class="package-npm-link" target="_blank" rel="noopener noreferrer">
+                    <svg class="npm-icon" viewBox="0 0 24 24" width="16" height="16">
+                        <path fill="currentColor" d="M0 0v24h24V0H0zm19.2 19.2H12V7.2h3.6v8.4h3.6V4.8H4.8v14.4h14.4v-4.8z"/>
+                    </svg>
+                    npm
+                </a>
+            </div>
+            <div class="community-package-card" data-category="utilities">
+                <div class="package-header">
+                    <span class="package-name">@asaasbr/n8n-nodes-asaas</span>
+                    <span class="package-category" data-category="utilities">utilities</span>
+                </div>
+                <p class="package-description">n8n nodes for integrating with the Asaas API</p>
+                <a href="https://www.npmjs.com/package/@asaasbr/n8n-nodes-asaas" class="package-npm-link" target="_blank" rel="noopener noreferrer">
+                    <svg class="npm-icon" viewBox="0 0 24 24" width="16" height="16">
+                        <path fill="currentColor" d="M0 0v24h24V0H0zm19.2 19.2H12V7.2h3.6v8.4h3.6V4.8H4.8v14.4h14.4v-4.8z"/>
+                    </svg>
+                    npm
+                </a>
+            </div>
+            <div class="community-package-card" data-category="utilities">
+                <div class="package-header">
+                    <span class="package-name">@apify/n8n-nodes-apify</span>
+                    <span class="package-category" data-category="utilities">utilities</span>
+                </div>
+                <p class="package-description">n8n nodes for Apify</p>
+                <a href="https://www.npmjs.com/package/@apify/n8n-nodes-apify" class="package-npm-link" target="_blank" rel="noopener noreferrer">
+                    <svg class="npm-icon" viewBox="0 0 24 24" width="16" height="16">
+                        <path fill="currentColor" d="M0 0v24h24V0H0zm19.2 19.2H12V7.2h3.6v8.4h3.6V4.8H4.8v14.4h14.4v-4.8z"/>
+                    </svg>
+                    npm
+                </a>
+            </div>
+            <div class="community-package-card" data-category="utilities">
+                <div class="package-header">
+                    <span class="package-name">n8n-nodes-youtube-transcript-api</span>
+                    <span class="package-category" data-category="utilities">utilities</span>
+                </div>
+                <p class="package-description">YouTube Transcript API Nodes for n8n</p>
+                <a href="https://www.npmjs.com/package/n8n-nodes-youtube-transcript-api" class="package-npm-link" target="_blank" rel="noopener noreferrer">
+                    <svg class="npm-icon" viewBox="0 0 24 24" width="16" height="16">
+                        <path fill="currentColor" d="M0 0v24h24V0H0zm19.2 19.2H12V7.2h3.6v8.4h3.6V4.8H4.8v14.4h14.4v-4.8z"/>
+                    </svg>
+                    npm
+                </a>
+            </div>
+            <div class="community-package-card" data-category="communication">
+                <div class="package-header">
+                    <span class="package-name">@pixelinfinito/n8n-nodes-chatwoot</span>
+                    <span class="package-category" data-category="communication">communication</span>
+                </div>
+                <p class="package-description">n8n community node for Chatwoot API integration</p>
+                <a href="https://www.npmjs.com/package/@pixelinfinito/n8n-nodes-chatwoot" class="package-npm-link" target="_blank" rel="noopener noreferrer">
+                    <svg class="npm-icon" viewBox="0 0 24 24" width="16" height="16">
+                        <path fill="currentColor" d="M0 0v24h24V0H0zm19.2 19.2H12V7.2h3.6v8.4h3.6V4.8H4.8v14.4h14.4v-4.8z"/>
+                    </svg>
+                    npm
+                </a>
+            </div>
+            <div class="community-package-card" data-category="ai-tools">
+                <div class="package-header">
+                    <span class="package-name">@mendable/n8n-nodes-firecrawl</span>
+                    <span class="package-category" data-category="ai-tools">ai-tools</span>
+                </div>
+                <p class="package-description">Official Firecrawl nodes for n8n - scrape, crawl, map, search, and extract data from websites. Supports AI Agent tool us...</p>
+                <a href="https://www.npmjs.com/package/@mendable/n8n-nodes-firecrawl" class="package-npm-link" target="_blank" rel="noopener noreferrer">
+                    <svg class="npm-icon" viewBox="0 0 24 24" width="16" height="16">
+                        <path fill="currentColor" d="M0 0v24h24V0H0zm19.2 19.2H12V7.2h3.6v8.4h3.6V4.8H4.8v14.4h14.4v-4.8z"/>
+                    </svg>
+                    npm
+                </a>
+            </div>
+            <div class="community-package-card" data-category="utilities">
+                <div class="package-header">
+                    <span class="package-name">n8n-nodes-thong-zalo-test-trial</span>
+                    <span class="package-category" data-category="utilities">utilities</span>
+                </div>
+                <p class="package-description">Các node hỗ trợ Zalo cho n8n</p>
+                <a href="https://www.npmjs.com/package/n8n-nodes-thong-zalo-test-trial" class="package-npm-link" target="_blank" rel="noopener noreferrer">
+                    <svg class="npm-icon" viewBox="0 0 24 24" width="16" height="16">
+                        <path fill="currentColor" d="M0 0v24h24V0H0zm19.2 19.2H12V7.2h3.6v8.4h3.6V4.8H4.8v14.4h14.4v-4.8z"/>
+                    </svg>
+                    npm
+                </a>
+            </div>
+            <div class="community-package-card" data-category="ai-tools">
+                <div class="package-header">
+                    <span class="package-name">n8n-nodes-transcript-lol</span>
+                    <span class="package-category" data-category="ai-tools">ai-tools</span>
+                </div>
+                <p class="package-description">n8n community node for Transcript.lol - AI-powered audio and video transcription service</p>
+                <a href="https://www.npmjs.com/package/n8n-nodes-transcript-lol" class="package-npm-link" target="_blank" rel="noopener noreferrer">
+                    <svg class="npm-icon" viewBox="0 0 24 24" width="16" height="16">
+                        <path fill="currentColor" d="M0 0v24h24V0H0zm19.2 19.2H12V7.2h3.6v8.4h3.6V4.8H4.8v14.4h14.4v-4.8z"/>
+                    </svg>
+                    npm
+                </a>
+            </div>
+            <div class="community-package-card" data-category="ai-tools">
+                <div class="package-header">
+                    <span class="package-name">n8n-nodes-mtai-zalo-test-trial</span>
+                    <span class="package-category" data-category="ai-tools">ai-tools</span>
+                </div>
+                <p class="package-description">Các node hỗ trợ Zalo cho n8n</p>
+                <a href="https://www.npmjs.com/package/n8n-nodes-mtai-zalo-test-trial" class="package-npm-link" target="_blank" rel="noopener noreferrer">
+                    <svg class="npm-icon" viewBox="0 0 24 24" width="16" height="16">
+                        <path fill="currentColor" d="M0 0v24h24V0H0zm19.2 19.2H12V7.2h3.6v8.4h3.6V4.8H4.8v14.4h14.4v-4.8z"/>
+                    </svg>
+                    npm
+                </a>
+            </div>
+        </div>
+                    <!-- END COMMUNITY_PACKAGES_LIST -->
+                </div>
+            </div>
+        </div>
+    </section>
+
+    <!-- Features Section -->
+    <section class="features">
+        <div class="container">
+            <h2 class="section-title">{{features.title}}</h2>
+            <div class="features-grid">
+                <div class="feature-card">
+                    <div class="feature-icon">📚</div>
+                    <h3 class="feature-title">{{features.comprehensive.title}}</h3>
+                    <p class="feature-description">{{features.comprehensive.description}}</p>
+                </div>
+                <div class="feature-card">
+                    <div class="feature-icon">🤖</div>
+                    <h3 class="feature-title">{{features.integration.title}}</h3>
+                    <p class="feature-description">{{features.integration.description}}</p>
+                </div>
+                <div class="feature-card">
+                    <div class="feature-icon">⚡</div>
+                    <h3 class="feature-title">{{features.priority.title}}</h3>
+                    <p class="feature-description">{{features.priority.description}}</p>
+                </div>
+                <div class="feature-card">
+                    <div class="feature-icon">🔄</div>
+                    <h3 class="feature-title">{{features.updates.title}}</h3>
+                    <p class="feature-description">{{features.updates.description}}</p>
+                </div>
+                <div class="feature-card">
+                    <div class="feature-icon">📁</div>
+                    <h3 class="feature-title">{{features.structure.title}}</h3>
+                    <p class="feature-description">{{features.structure.description}}</p>
+                </div>
+            </div>
+        </div>
+    </section>
+
+    <!-- How It Works Section -->
+    <section class="how-it-works">
+        <div class="container">
+            <h2 class="section-title">{{howItWorks.title}}</h2>
+            <div class="steps-grid">
+                <div class="step-card">
+                    <div class="step-number">1</div>
+                    <h3 class="step-title">{{howItWorks.step1.title}}</h3>
+                    <p class="step-description">{{howItWorks.step1.description}}</p>
+                </div>
+                <div class="step-card">
+                    <div class="step-number">2</div>
+                    <h3 class="step-title">{{howItWorks.step2.title}}</h3>
+                    <p class="step-description">{{howItWorks.step2.description}}</p>
+                </div>
+                <div class="step-card">
+                    <div class="step-number">3</div>
+                    <h3 class="step-title">{{howItWorks.step3.title}}</h3>
+                    <p class="step-description">{{howItWorks.step3.description}}</p>
+                </div>
+            </div>
+        </div>
+    </section>
+
+    <!-- Installation Section -->
+    <section class="installation" id="installation">
+        <div class="container">
+            <h2 class="section-title">{{installation.title}}</h2>
+            <p class="section-subtitle">{{installation.subtitle}}</p>
+            <div class="installation-grid">
+                <!-- Claude Code Plugin -->
+                <div class="install-card install-card-primary">
+                    <div class="install-icon">
+                        <svg width="48" height="48" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+                            <path d="M4 17l6-6-6-6M12 19h8"/>
+                        </svg>
+                    </div>
+                    <h3 class="install-title">{{installation.plugin.title}}</h3>
+                    <p class="install-description">{{installation.plugin.description}}</p>
+                    <div class="install-command">
+                        <code>/plugin marketplace add haunchen/n8n-skills-pack</code>
+                        <button class="copy-btn" data-copy="/plugin marketplace add haunchen/n8n-skills-pack" aria-label="Copy command">
+                            <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+                                <rect x="9" y="9" width="13" height="13" rx="2" ry="2"></rect>
+                                <path d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1"></path>
+                            </svg>
+                        </button>
+                    </div>
+                    <div class="install-command">
+                        <code>/plugin install n8n-skills@n8n-skills-pack</code>
+                        <button class="copy-btn" data-copy="/plugin install n8n-skills@n8n-skills-pack" aria-label="Copy command">
+                            <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+                                <rect x="9" y="9" width="13" height="13" rx="2" ry="2"></rect>
+                                <path d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1"></path>
+                            </svg>
+                        </button>
+                    </div>
+                    <span class="install-badge">{{installation.plugin.badge}}</span>
+                </div>
+
+                <!-- Manual Install -->
+                <div class="install-card">
+                    <div class="install-icon">
+                        <svg width="48" height="48" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+                            <path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4"/>
+                            <polyline points="7 10 12 15 17 10"/>
+                            <line x1="12" y1="15" x2="12" y2="3"/>
+                        </svg>
+                    </div>
+                    <h3 class="install-title">{{installation.manual.title}}</h3>
+                    <p class="install-description">{{installation.manual.description}}</p>
+                    <a href="https://github.com/haunchen/n8n-skills/releases" class="btn btn-secondary install-btn" target="_blank" rel="noopener noreferrer">
+                        <span>{{installation.manual.button}}</span>
+                        <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+                            <path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4"/>
+                            <polyline points="7 10 12 15 17 10"/>
+                            <line x1="12" y1="15" x2="12" y2="3"/>
+                        </svg>
+                    </a>
+                </div>
+            </div>
+        </div>
+    </section>
+
+    <!-- Categories Section -->
+    <section class="categories">
+        <div class="container">
+            <h2 class="section-title">{{categories.title}}</h2>
+            <div class="categories-grid">
+                <div class="category-card">
+                    <h3 class="category-title">{{categories.core.title}}</h3>
+                    <p class="category-description">{{categories.core.description}}</p>
+                </div>
+                <div class="category-card">
+                    <h3 class="category-title">{{categories.apps.title}}</h3>
+                    <p class="category-description">{{categories.apps.description}}</p>
+                </div>
+                <div class="category-card">
+                    <h3 class="category-title">{{categories.triggers.title}}</h3>
+                    <p class="category-description">{{categories.triggers.description}}</p>
+                </div>
+                <div class="category-card">
+                    <h3 class="category-title">{{categories.ai.title}}</h3>
+                    <p class="category-description">{{categories.ai.description}}</p>
+                </div>
+                <div class="category-card">
+                    <h3 class="category-title">{{categories.database.title}}</h3>
+                    <p class="category-description">{{categories.database.description}}</p>
+                </div>
+                <div class="category-card">
+                    <h3 class="category-title">{{categories.tools.title}}</h3>
+                    <p class="category-description">{{categories.tools.description}}</p>
+                </div>
+            </div>
+        </div>
+    </section>
+
+    <!-- Footer -->
+    <footer class="footer">
+        <div class="container">
+            <div class="footer-grid">
+                <!-- 左欄：品牌資訊 -->
+                <div class="footer-brand">
+                    <div class="footer-brand-header">
+                        <img src="{{__base_path__}}assets/n8n-skills-icon.png" alt="n8n Skills Logo" class="footer-icon">
+                        <h3 class="footer-logo">{{footer.brandName}}</h3>
+                    </div>
+                    <p class="footer-slogan">{{footer.slogan}}</p>
+                </div>
+
+                <!-- 中欄：產品資訊 -->
+                <div class="footer-links-group">
+                    <h4 class="footer-group-title">{{footer.productInfo}}</h4>
+                    <ul class="footer-links-list">
+                        <li><a href="https://github.com/haunchen/n8n-skills" target="_blank"
+                                rel="noopener noreferrer">GitHub</a></li>
+                        <li><a href="https://github.com/haunchen/n8n-skills/releases" target="_blank"
+                                rel="noopener noreferrer">Releases</a></li>
+                        <li><a href="#features">{{footer.features}}</a></li>
+                        <li><a href="#how-it-works">{{footer.howToUse}}</a></li>
+                    </ul>
+                </div>
+
+                <!-- 右欄：其他資源 -->
+                <div class="footer-links-group">
+                    <h4 class="footer-group-title">{{footer.otherResources}}</h4>
+                    <ul class="footer-links-list">
+                        <li><a href="https://www.frankchen.tw/" target="_blank" rel="noopener noreferrer">{{footer.home}}</a></li>
+                        <li><a href="https://www.frankchen.tw/n8n-resources/" target="_blank" rel="noopener noreferrer">{{footer.n8nTutorial}}</a></li>
+                        <li><a href="https://www.frankchen.tw/personal/" target="_blank" rel="noopener noreferrer">{{footer.aboutMe}}</a></li>
+                        <li><a href="https://www.frankchen.tw/contact-frank/" target="_blank" rel="noopener noreferrer">{{footer.contactMe}}</a></li>
+                    </ul>
+                </div>
+            </div>
+
+            <!-- 底部版權 -->
+            <div class="footer-bottom">
+                <p class="footer-copyright">{{footer.copyright}}</p>
+            </div>
+        </div>
+    </footer>
+
+    <script src="{{__base_path__}}script.js"></script>
+</body>
+
+</html>

--- a/website/zh-TW/index.html
+++ b/website/zh-TW/index.html
@@ -69,7 +69,7 @@
 
 <body>
     <!-- Fixed Language Toggle Button -->
-    <button id="lang-toggle" class="lang-toggle-fixed" onclick="window.location.href='https://n8n-skills.frankchen.tw/'">
+    <button id="lang-toggle" class="lang-toggle-fixed" onclick="window.location.href='/'">
         <span class="lang-icon">🌐</span>
         <span class="lang-text">English</span>
     </button>
@@ -100,7 +100,7 @@
                 <div class="license-badge">
                     <span>Open Source MIT License</span>
                 </div>
-                <h1 class="hero-title">n8n Skills<span class="hero-title-separator"> — </span><span class="hero-title-sub">讓 AI 助理成為你的 n8n 工作流程專家</span></h1>
+                <h1 class="hero-title">n8n Skills<span class="hero-title-sub">讓 AI 助理成為你的 n8n 工作流程專家</span></h1>
                 <p class="hero-description">545 個節點的完整知識庫，定期更新，智慧排序</p>
                 <div class="hero-buttons">
                     <a href="https://github.com/haunchen/n8n-skills" class="btn btn-primary" target="_blank"

--- a/website/zh-TW/index.html
+++ b/website/zh-TW/index.html
@@ -1,19 +1,19 @@
 <!DOCTYPE html>
-<html lang="en">
+<html lang="zh-TW">
 
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
     <!-- Primary Meta Tags -->
-    <title>n8n Skills - n8n Workflow Knowledge Base for AI Assistants</title>
-    <meta name="title" content="n8n Skills - n8n Workflow Knowledge Base for AI Assistants">
-    <meta name="description" content="Turn your AI assistant into an n8n workflow expert. Complete knowledge base with 545 nodes, supports Claude Code, Claude.ai Web, and Claude Desktop.">
-    <meta name="keywords" content="n8n, workflow automation, AI assistant, Claude, skill pack, n8n nodes, workflow automation, n8n nodes">
+    <title>n8n Skills - AI 助理的 n8n 工作流程知識庫</title>
+    <meta name="title" content="n8n Skills - AI 助理的 n8n 工作流程知識庫">
+    <meta name="description" content="讓 AI 助理成為你的 n8n 工作流程專家。包含 545 個節點的完整知識庫，支援 Claude Code、Claude.ai Web 和 Claude Desktop。">
+    <meta name="keywords" content="n8n, workflow automation, AI assistant, Claude, skill pack, n8n nodes, 工作流程自動化, n8n 節點">
     <meta name="author" content="Frank Chen">
     <meta name="robots" content="index, follow">
-    <link rel="canonical" href="https://n8n-skills.frankchen.tw/">
-    <link rel="icon" href="./assets/n8n-skills-icon.png">
+    <link rel="canonical" href="https://n8n-skills.frankchen.tw/zh-TW/">
+    <link rel="icon" href="../assets/n8n-skills-icon.png">
 
     <!-- Hreflang -->
     <link rel="alternate" hreflang="en" href="https://n8n-skills.frankchen.tw/">
@@ -22,17 +22,17 @@
 
     <!-- Open Graph / Facebook -->
     <meta property="og:type" content="website">
-    <meta property="og:url" content="https://n8n-skills.frankchen.tw/">
-    <meta property="og:title" content="n8n Skills - n8n Workflow Knowledge Base for AI Assistants">
-    <meta property="og:description" content="Turn your AI assistant into an n8n workflow expert. Complete knowledge base with 545 nodes, supports Claude Code, Claude.ai Web, and Claude Desktop.">
-    <meta property="og:locale" content="en_US">
+    <meta property="og:url" content="https://n8n-skills.frankchen.tw/zh-TW/">
+    <meta property="og:title" content="n8n Skills - AI 助理的 n8n 工作流程知識庫">
+    <meta property="og:description" content="讓 AI 助理成為你的 n8n 工作流程專家。包含 545 個節點的完整知識庫，支援 Claude Code、Claude.ai Web 和 Claude Desktop。">
+    <meta property="og:locale" content="zh_TW">
     <meta property="og:image" content="https://n8n-skills.frankchen.tw/assets/n8n-skills-icon.png">
 
     <!-- Twitter -->
     <meta property="twitter:card" content="summary_large_image">
-    <meta property="twitter:url" content="https://n8n-skills.frankchen.tw/">
-    <meta property="twitter:title" content="n8n Skills - n8n Workflow Knowledge Base for AI Assistants">
-    <meta property="twitter:description" content="Turn your AI assistant into an n8n workflow expert. Complete knowledge base with 545 nodes, supports Claude Code, Claude.ai Web, and Claude Desktop.">
+    <meta property="twitter:url" content="https://n8n-skills.frankchen.tw/zh-TW/">
+    <meta property="twitter:title" content="n8n Skills - AI 助理的 n8n 工作流程知識庫">
+    <meta property="twitter:description" content="讓 AI 助理成為你的 n8n 工作流程專家。包含 545 個節點的完整知識庫，支援 Claude Code、Claude.ai Web 和 Claude Desktop。">
     <meta property="twitter:image" content="https://n8n-skills.frankchen.tw/assets/n8n-skills-icon.png">
 
     <!-- Theme Color -->
@@ -41,8 +41,8 @@
     <!-- Preconnect to external domains -->
     <link rel="preconnect" href="https://github.com" crossorigin>
 
-    <link rel="stylesheet" href="./styles.css">
-    <script src="./i18n.js"></script>
+    <link rel="stylesheet" href="../styles.css">
+    <script src="../i18n.js"></script>
 
     <!-- Structured Data (JSON-LD) -->
     <script type="application/ld+json">
@@ -57,7 +57,7 @@
         "priceCurrency": "USD"
       },
       "operatingSystem": "Cross-platform",
-      "description": "Turn your AI assistant into an n8n workflow expert. Complete knowledge base with 545 nodes, supports Claude Code, Claude.ai Web, and Claude Desktop.",
+      "description": "讓 AI 助理成為你的 n8n 工作流程專家。包含 545 個節點的完整知識庫，支援 Claude Code、Claude.ai Web 和 Claude Desktop。",
       "author": {
         "@type": "Person",
         "name": "Frank Chen"
@@ -69,9 +69,9 @@
 
 <body>
     <!-- Fixed Language Toggle Button -->
-    <button id="lang-toggle" class="lang-toggle-fixed" onclick="window.location.href='https://n8n-skills.frankchen.tw/zh-TW/'">
+    <button id="lang-toggle" class="lang-toggle-fixed" onclick="window.location.href='https://n8n-skills.frankchen.tw/'">
         <span class="lang-icon">🌐</span>
-        <span class="lang-text">中文</span>
+        <span class="lang-text">English</span>
     </button>
 
     <!-- Sticky Navbar -->
@@ -80,7 +80,7 @@
             <div class="navbar-brand">n8n Skills</div>
             <div class="navbar-buttons">
                 <a href="https://github.com/haunchen/n8n-skills" class="btn btn-primary btn-nav" target="_blank"
-                    rel="noopener noreferrer" aria-label="Visit n8n Skills GitHub repository">
+                    rel="noopener noreferrer" aria-label="前往 n8n Skills GitHub 專案">
                     <svg width="20" height="20" fill="currentColor" viewBox="0 0 16 16" aria-hidden="true">
                         <path
                             d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27.68 0 1.36.09 2 .27 1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.012 8.012 0 0 0 16 8c0-4.42-3.58-8-8-8z" />
@@ -88,7 +88,7 @@
                     GitHub
                 </a>
                 <a href="https://github.com/haunchen/n8n-skills/releases" class="btn btn-secondary btn-nav"
-                    target="_blank" rel="noopener noreferrer" aria-label="Download the latest version of n8n Skills">Get Started</a>
+                    target="_blank" rel="noopener noreferrer" aria-label="下載最新版本的 n8n Skills">開始使用</a>
             </div>
         </div>
     </nav>
@@ -100,11 +100,11 @@
                 <div class="license-badge">
                     <span>Open Source MIT License</span>
                 </div>
-                <h1 class="hero-title">n8n Skills<span class="hero-title-separator"> — </span><span class="hero-title-sub">Turn your AI assistant into an n8n workflow expert</span></h1>
-                <p class="hero-description">Complete knowledge base with 545 nodes, regularly updated, intelligently prioritized</p>
+                <h1 class="hero-title">n8n Skills<span class="hero-title-separator"> — </span><span class="hero-title-sub">讓 AI 助理成為你的 n8n 工作流程專家</span></h1>
+                <p class="hero-description">545 個節點的完整知識庫，定期更新，智慧排序</p>
                 <div class="hero-buttons">
                     <a href="https://github.com/haunchen/n8n-skills" class="btn btn-primary" target="_blank"
-                        rel="noopener noreferrer" aria-label="Visit n8n Skills GitHub repository">
+                        rel="noopener noreferrer" aria-label="前往 n8n Skills GitHub 專案">
                         <svg width="20" height="20" fill="currentColor" viewBox="0 0 16 16" aria-hidden="true">
                             <path
                                 d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27.68 0 1.36.09 2 .27 1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.012 8.012 0 0 0 16 8c0-4.42-3.58-8-8-8z" />
@@ -112,7 +112,7 @@
                         GitHub
                     </a>
                     <a href="https://github.com/haunchen/n8n-skills/releases" class="btn btn-secondary" target="_blank"
-                        rel="noopener noreferrer" aria-label="Download the latest version of n8n Skills">Get Started</a>
+                        rel="noopener noreferrer" aria-label="下載最新版本的 n8n Skills">開始使用</a>
                 </div>
             </div>
         </div>
@@ -124,26 +124,26 @@
             <div class="stats-grid">
                 <div class="stat-card">
                     <div class="stat-number">545</div>
-                    <div class="stat-label">n8n Nodes</div>
+                    <div class="stat-label">n8n 節點</div>
                 </div>
                 <div class="stat-card">
                     <div class="stat-number">6</div>
-                    <div class="stat-label">Main Categories</div>
+                    <div class="stat-label">主要分類</div>
                 </div>
                 <div class="stat-card">
                     <div class="stat-number">20</div>
-                    <div class="stat-label">Workflow Templates</div>
+                    <div class="stat-label">工作流程範本</div>
                 </div>
                 <div class="stat-card stat-card-clickable" id="community-stats-card">
                     <div class="stat-number">30</div>
-                    <div class="stat-label">Community Packages</div>
-                    <div class="stat-expand-hint">Click to expand</div>
+                    <div class="stat-label">社群套件</div>
+                    <div class="stat-expand-hint">點擊展開</div>
                 </div>
             </div>
             <!-- Community Packages Section -->
             <div class="community-packages-section" id="community-packages-section">
                 <div class="community-packages-header" id="community-packages-toggle">
-                    <h3 class="community-packages-title">Recommended Community Packages</h3>
+                    <h3 class="community-packages-title">社群套件推薦</h3>
                     <span class="community-packages-toggle-icon">▼</span>
                 </div>
                 <div class="community-packages-content" id="community-packages-content">
@@ -549,32 +549,32 @@
     <!-- Features Section -->
     <section class="features">
         <div class="container">
-            <h2 class="section-title">Features</h2>
+            <h2 class="section-title">核心特色</h2>
             <div class="features-grid">
                 <div class="feature-card">
                     <div class="feature-icon">📚</div>
-                    <h3 class="feature-title">Comprehensive Node Knowledge Base</h3>
-                    <p class="feature-description">Detailed documentation for 545 n8n nodes, organized into 6 main categories, supports the latest n8n v2.13.4</p>
+                    <h3 class="feature-title">全面的節點知識庫</h3>
+                    <p class="feature-description">包含 545 個 n8n 節點的詳細文件，按照 6 個主要分類組織，支援最新的 n8n v2.13.4</p>
                 </div>
                 <div class="feature-card">
                     <div class="feature-icon">🤖</div>
-                    <h3 class="feature-title">Multi-Platform AI Integration</h3>
-                    <p class="feature-description">Supports Claude Code, Claude.ai Web, and Claude Desktop through seamless Skill Pack format integration</p>
+                    <h3 class="feature-title">多平台 AI 整合</h3>
+                    <p class="feature-description">支援 Claude Code、Claude.ai Web 和 Claude Desktop，通過 Skill Pack 格式無縫整合</p>
                 </div>
                 <div class="feature-card">
                     <div class="feature-icon">⚡</div>
-                    <h3 class="feature-title">Priority Ranking</h3>
-                    <p class="feature-description">Multi-dimensional scoring system based on usage frequency, documentation completeness, community popularity, and versatility</p>
+                    <h3 class="feature-title">優先級排序</h3>
+                    <p class="feature-description">基於使用頻率、文件完整度、社群受歡迎程度和通用性的多維度評分系統</p>
                 </div>
                 <div class="feature-card">
                     <div class="feature-icon">🔄</div>
-                    <h3 class="feature-title">Regular Release Updates</h3>
-                    <p class="feature-description">Automatically tracks the latest n8n versions weekly and publishes updates, download to get the latest content</p>
+                    <h3 class="feature-title">定期發布更新</h3>
+                    <p class="feature-description">每週自動追蹤 n8n 最新版本並發布更新，下載即可獲得最新內容</p>
                 </div>
                 <div class="feature-card">
                     <div class="feature-icon">📁</div>
-                    <h3 class="feature-title">Complete Resource Structure</h3>
-                    <p class="feature-description">Main SKILL.md provides quick reference, resources/ directory contains detailed documentation and templates organized by category</p>
+                    <h3 class="feature-title">完整資源結構</h3>
+                    <p class="feature-description">主 SKILL.md 提供快速參考，resources/ 目錄包含按分類組織的詳細文件和範本</p>
                 </div>
             </div>
         </div>
@@ -583,22 +583,22 @@
     <!-- How It Works Section -->
     <section class="how-it-works">
         <div class="container">
-            <h2 class="section-title">How to Use</h2>
+            <h2 class="section-title">如何使用</h2>
             <div class="steps-grid">
                 <div class="step-card">
                     <div class="step-number">1</div>
-                    <h3 class="step-title">Download n8n Skills</h3>
-                    <p class="step-description">Download the latest version of n8n Skills from GitHub Releases</p>
+                    <h3 class="step-title">下載 n8n Skills</h3>
+                    <p class="step-description">從 GitHub Releases 下載最新版本的 n8n Skills</p>
                 </div>
                 <div class="step-card">
                     <div class="step-number">2</div>
-                    <h3 class="step-title">Install to AI Assistant</h3>
-                    <p class="step-description">Import n8n Skills into your Claude Code, Web, or Desktop</p>
+                    <h3 class="step-title">安裝到 AI 助理</h3>
+                    <p class="step-description">將 n8n Skills 導入你的 Claude Code、Web 或 Desktop</p>
                 </div>
                 <div class="step-card">
                     <div class="step-number">3</div>
-                    <h3 class="step-title">Start Using</h3>
-                    <p class="step-description">Ask your AI assistant questions about n8n nodes and workflows</p>
+                    <h3 class="step-title">開始使用</h3>
+                    <p class="step-description">詢問 AI 助理關於 n8n 節點和工作流程的問題</p>
                 </div>
             </div>
         </div>
@@ -607,8 +607,8 @@
     <!-- Installation Section -->
     <section class="installation" id="installation">
         <div class="container">
-            <h2 class="section-title">Quick Install</h2>
-            <p class="section-subtitle">Choose the installation method that works best for you</p>
+            <h2 class="section-title">快速安裝</h2>
+            <p class="section-subtitle">選擇最適合你的安裝方式</p>
             <div class="installation-grid">
                 <!-- Claude Code Plugin -->
                 <div class="install-card install-card-primary">
@@ -618,7 +618,7 @@
                         </svg>
                     </div>
                     <h3 class="install-title">Claude Code Plugin</h3>
-                    <p class="install-description">Two-step install</p>
+                    <p class="install-description">兩步驟安裝</p>
                     <div class="install-command">
                         <code>/plugin marketplace add haunchen/n8n-skills-pack</code>
                         <button class="copy-btn" data-copy="/plugin marketplace add haunchen/n8n-skills-pack" aria-label="Copy command">
@@ -637,7 +637,7 @@
                             </svg>
                         </button>
                     </div>
-                    <span class="install-badge">Recommended</span>
+                    <span class="install-badge">推薦</span>
                 </div>
 
                 <!-- Manual Install -->
@@ -649,10 +649,10 @@
                             <line x1="12" y1="15" x2="12" y2="3"/>
                         </svg>
                     </div>
-                    <h3 class="install-title">Manual Install</h3>
-                    <p class="install-description">Download and copy to skills directory</p>
+                    <h3 class="install-title">手動安裝</h3>
+                    <p class="install-description">下載並複製到 skills 目錄</p>
                     <a href="https://github.com/haunchen/n8n-skills/releases" class="btn btn-secondary install-btn" target="_blank" rel="noopener noreferrer">
-                        <span>Download ZIP</span>
+                        <span>下載 ZIP</span>
                         <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
                             <path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4"/>
                             <polyline points="7 10 12 15 17 10"/>
@@ -667,31 +667,31 @@
     <!-- Categories Section -->
     <section class="categories">
         <div class="container">
-            <h2 class="section-title">Node Categories</h2>
+            <h2 class="section-title">節點分類</h2>
             <div class="categories-grid">
                 <div class="category-card">
-                    <h3 class="category-title">Core Nodes</h3>
-                    <p class="category-description">Essential nodes like HTTP Request, Code, Webhook, Set, If, Merge, etc.</p>
+                    <h3 class="category-title">核心節點</h3>
+                    <p class="category-description">HTTP Request、Code、Webhook、Set、If、Merge 等基礎節點</p>
                 </div>
                 <div class="category-card">
-                    <h3 class="category-title">App Integrations</h3>
-                    <p class="category-description">30+ popular app integrations including Google, Slack, Discord, and more</p>
+                    <h3 class="category-title">應用整合</h3>
+                    <p class="category-description">30+ 個熱門應用整合，包含 Google、Slack、Discord 等</p>
                 </div>
                 <div class="category-card">
-                    <h3 class="category-title">Triggers</h3>
-                    <p class="category-description">Various trigger methods including Webhook, Schedule, Email, and more</p>
+                    <h3 class="category-title">觸發器</h3>
+                    <p class="category-description">Webhook、Schedule、Email 等多種觸發方式</p>
                 </div>
                 <div class="category-card">
-                    <h3 class="category-title">AI Nodes</h3>
-                    <p class="category-description">20+ AI-related nodes supporting various AI model integrations</p>
+                    <h3 class="category-title">AI 節點</h3>
+                    <p class="category-description">20+ 個 AI 相關節點，支援各種 AI 模型整合</p>
                 </div>
                 <div class="category-card">
-                    <h3 class="category-title">Databases</h3>
-                    <p class="category-description">Database connectors for MongoDB, PostgreSQL, MySQL, and more</p>
+                    <h3 class="category-title">資料庫</h3>
+                    <p class="category-description">MongoDB、PostgreSQL、MySQL 等資料庫連接器</p>
                 </div>
                 <div class="category-card">
-                    <h3 class="category-title">Utility Nodes</h3>
-                    <p class="category-description">Practical tools for data processing, file operations, format conversion, and more</p>
+                    <h3 class="category-title">工具節點</h3>
+                    <p class="category-description">資料處理、檔案操作、格式轉換等實用工具</p>
                 </div>
             </div>
         </div>
@@ -704,45 +704,45 @@
                 <!-- 左欄：品牌資訊 -->
                 <div class="footer-brand">
                     <div class="footer-brand-header">
-                        <img src="./assets/n8n-skills-icon.png" alt="n8n Skills Logo" class="footer-icon">
+                        <img src="../assets/n8n-skills-icon.png" alt="n8n Skills Logo" class="footer-icon">
                         <h3 class="footer-logo">n8n Skills</h3>
                     </div>
-                    <p class="footer-slogan">Turn your AI assistant into an n8n workflow expert</p>
+                    <p class="footer-slogan">讓 AI 助理成為你的 n8n 工作流程專家</p>
                 </div>
 
                 <!-- 中欄：產品資訊 -->
                 <div class="footer-links-group">
-                    <h4 class="footer-group-title">n8n Skills Info</h4>
+                    <h4 class="footer-group-title">n8n Skills 的資訊</h4>
                     <ul class="footer-links-list">
                         <li><a href="https://github.com/haunchen/n8n-skills" target="_blank"
                                 rel="noopener noreferrer">GitHub</a></li>
                         <li><a href="https://github.com/haunchen/n8n-skills/releases" target="_blank"
                                 rel="noopener noreferrer">Releases</a></li>
-                        <li><a href="#features">Features</a></li>
-                        <li><a href="#how-it-works">How to Use</a></li>
+                        <li><a href="#features">功能介紹</a></li>
+                        <li><a href="#how-it-works">如何使用</a></li>
                     </ul>
                 </div>
 
                 <!-- 右欄：其他資源 -->
                 <div class="footer-links-group">
-                    <h4 class="footer-group-title">More from Frank</h4>
+                    <h4 class="footer-group-title">法蘭克的其他資源</h4>
                     <ul class="footer-links-list">
-                        <li><a href="https://www.frankchen.tw/" target="_blank" rel="noopener noreferrer">Home</a></li>
-                        <li><a href="https://www.frankchen.tw/n8n-resources/" target="_blank" rel="noopener noreferrer">n8n Tutorial</a></li>
-                        <li><a href="https://www.frankchen.tw/personal/" target="_blank" rel="noopener noreferrer">About Me</a></li>
-                        <li><a href="https://www.frankchen.tw/contact-frank/" target="_blank" rel="noopener noreferrer">Contact Me</a></li>
+                        <li><a href="https://www.frankchen.tw/" target="_blank" rel="noopener noreferrer">首頁</a></li>
+                        <li><a href="https://www.frankchen.tw/n8n-resources/" target="_blank" rel="noopener noreferrer">n8n 教學</a></li>
+                        <li><a href="https://www.frankchen.tw/personal/" target="_blank" rel="noopener noreferrer">關於我</a></li>
+                        <li><a href="https://www.frankchen.tw/contact-frank/" target="_blank" rel="noopener noreferrer">聯絡我</a></li>
                     </ul>
                 </div>
             </div>
 
             <!-- 底部版權 -->
             <div class="footer-bottom">
-                <p class="footer-copyright">© 2025 Frank Chen. All rights reserved.</p>
+                <p class="footer-copyright">© 2025 法蘭克 All rights reserved.</p>
             </div>
         </div>
     </footer>
 
-    <script src="./script.js"></script>
+    <script src="../script.js"></script>
 </body>
 
 </html>

--- a/website/zh-TW/index.html
+++ b/website/zh-TW/index.html
@@ -738,6 +738,7 @@
             <!-- 底部版權 -->
             <div class="footer-bottom">
                 <p class="footer-copyright">© 2025 法蘭克 All rights reserved.</p>
+                <p class="footer-version">支援 n8n v2.13.4 | 最後更新：2026-03-30</p>
             </div>
         </div>
     </footer>


### PR DESCRIPTION
## Summary

- 將 client-side i18n 改為 build-time 靜態 HTML 生成，解決搜尋引擎無法索引英文內容的問題
- 新增 `template.html` 模板系統，`update-website.ts` 讀取模板 + locale JSONs 生成 `index.html`（EN）和 `zh-TW/index.html`（ZH-TW）
- SEO 修正：hreflang 標籤、og:image/twitter:image、favicon、JSON-LD 移除假 aggregateRating、H1 改善
- 網域更新為 `n8n-skills.frankchen.tw`

## Changes

- `website/template.html` — 新增 HTML 模板，所有文字用 `{{key.path}}` 佔位符
- `scripts/update-website.ts` — 新增 `generateLocalizedPages()`、`updateTemplateStats()`，更新 `updateSitemap()` 和 `updateCommunityPackages()`
- `website/i18n.js` — 從 193 行 I18n class 精簡為 22 行 URL-based 語言偵測
- `website/script.js` — 移除所有 client-side i18n 程式碼
- `website/sitemap.xml` — 包含 EN 和 ZH-TW 兩個 URL
- `website/robots.txt` — 更新為新網域

## Test Plan

- [x] `npm run update:website` 成功生成兩份 HTML
- [x] 生成的 HTML 無未解析佔位符（`grep '{{' → 0`）
- [x] 生成的 HTML 無 data-i18n 屬性殘留
- [x] hreflang 標籤正確（en, zh-TW, x-default）
- [x] sitemap 包含兩個 URL
- [x] TypeScript 編譯通過（`tsc --noEmit`）
- [ ] 部署後驗證 Google Search Console 索引